### PR TITLE
fix(404s): redirect to root index.html for each class and property

### DIFF
--- a/ontology/dprod/dprod-data
+++ b/ontology/dprod/dprod-data
@@ -9,7 +9,7 @@
 
 
 @prefix dprod-data: <https://ekgf.github.io/dprod/data/> .
-@prefix dprod: <https://ekgf.github.io/dprod/#> .
+@prefix dprod: <https://ekgf.github.io/dprod/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/>.
@@ -37,7 +37,7 @@ dprod-data:
    owl:imports <http://www.w3.org/2004/02/skos/core>;
    owl:imports <http://www.w3.org/ns/prov-o#>;
    owl:imports <http://www.w3.org/ns/dcat>;
-   owl:imports <https://ekgf.github.io/dprod/#>;
+   owl:imports <https://ekgf.github.io/dprod/>;
    dct:creator [
      a foaf:Person ;
      foaf:name "Natasa Varytimou" ;

--- a/ontology/dprod/dprod-redundant.ttl
+++ b/ontology/dprod/dprod-redundant.ttl
@@ -8,7 +8,7 @@
 
 
 
-@prefix dprod: <https://ekgf.github.io/dprod/#> .
+@prefix dprod: <https://ekgf.github.io/dprod/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/>.

--- a/respec/template.html
+++ b/respec/template.html
@@ -567,7 +567,7 @@
     the shared FIBO specification for callable bonds.
   </p>
 
-  <pre id="eg12" class="example hljs json">
+  <pre id="eg12" class="example hljs json ekgfexample">
   {
     "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
     "id": "https://y.com/products/uk-bonds",
@@ -611,7 +611,7 @@
         <p>
           <table class="def propdef">
           <tbody>
-            <tr><th>Identifier:</th><td><a href="{{prop.uri}}">{{prop.short_uri}}</a></td></tr>
+            <tr><th>Identifier:</th><td><a href="#{{prop.name.lower()}}">{{prop.short_uri}}</a></td></tr>
             {% if prop.label is not none and prop.label  != '' %}   
             <tr><th>Label:</th><td>{{prop.label}}</td></tr>
             {% endif %}


### PR DESCRIPTION
When someone clicks on https://ekgf.github.io/dprod/DataProduct we do not want a 404 message but a redirect to https://ekgf.github.io/dprod/#dataproduct