### PR TITLE
fix(#93): make dprod.jsonld a proper JSON-LD context; split out ontology to dprod-ontology.jsonld

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,12 @@ source .venv/bin/activate
 python spec-generator/main.py
 ```
 
-There are no tests or linters configured.
+To run tests (requires a prior build so `dist/` is populated):
+
+```bash
+source .venv/bin/activate
+pytest tests/
+```
 
 ## Architecture
 
@@ -34,7 +39,7 @@ The spec generator (`spec-generator/main.py`) produces the specification HTML an
 3. **Two-pass property loading** — For both NodeShapes and PropertyShapes, OWL properties are loaded first, then SHACL properties override them. Predicates in `IGNORED_NODE_SHAPE_PREDICATES` / `IGNORED_PROPERTY_SHAPE_PREDICATES` (in `globals.py`) are skipped during the SHACL pass to prevent shape metadata from leaking into the spec.
 4. **Examples** — Each subdirectory in `examples/` with a `README.md` is loaded; the markdown is converted to HTML.
 5. **Render** — Jinja2 renders `respec/template.html` with the discovered classes and examples, producing `dist/index.html`.
-6. **Serialize** — The ontology is serialized to Turtle, JSON-LD, and RDF/XML in multiple combinations (ontology-only, shapes-only, combined). A standalone `dprod-context.jsonld` is also generated for use as a remote `@context` in JSON-LD documents.
+6. **Serialize** — The ontology is serialized to Turtle, JSON-LD, and RDF/XML in multiple combinations (ontology-only, shapes-only, combined). `dprod.jsonld` is a proper JSON-LD context with term mappings (for use as a remote `@context` in instance documents). `dprod-ontology.jsonld` is the OWL ontology serialized as JSON-LD.
 
 ### Key relationships
 
@@ -42,7 +47,7 @@ The spec generator (`spec-generator/main.py`) produces the specification HTML an
 - `dprod-shapes.ttl` defines SHACL shapes that constrain those classes (the "how to validate"). Each NodeShape targets an OWL class; each PropertyShape constrains an OWL property via `sh:path`.
 - `respec/template.html` is both a W3C ReSpec document and a Jinja2 template. Static sections (preamble, scope, namespaces) are plain HTML. Dynamic sections use `{% for cls in classes %}` loops to render class and property tables.
 - Class ordering in the spec is hardcoded in `main.py` (the `reorder_list` call), not derived from the ontology.
-- Examples referenced in `@context` use `dprod-context.jsonld` (standalone context), not `dprod.jsonld` (full ontology dump).
+- `dprod.jsonld` is a proper JSON-LD context document (term mappings + namespace prefixes). `dprod-ontology.jsonld` is the OWL ontology as JSON-LD. Examples reference `dprod.jsonld` in their `@context`.
 
 ### Namespace
 

--- a/examples/core-data-product-extensions/README.md
+++ b/examples/core-data-product-extensions/README.md
@@ -12,7 +12,7 @@ In this example, a Data Product Agreement is defined as a subclass of FIBO Agree
 [
   {
     "@context": [
-      "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+      "https://www.omg.org/spec/DPROD/dprod.jsonld",
       {
         "fibo": "http://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/#",
         "ex": "http://example.org/dp#"
@@ -50,7 +50,7 @@ Below is an example of a Data Product with an associated Data Product Agreement 
 ```json
 {
   "@context": [
-    "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "https://www.omg.org/spec/DPROD/dprod.jsonld",
     {
       "fibo": "http://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/#",
       "ex": "http://example.org/dp#"

--- a/examples/data-lineage/README.md
+++ b/examples/data-lineage/README.md
@@ -25,7 +25,7 @@ connect to each other through their input and output ports:
 
 ```json
 {
-  "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "dataProducts": [
     {
       "id": "https://y.com/data-product/company-finance",

--- a/examples/data-quality/example.jsonld
+++ b/examples/data-quality/example.jsonld
@@ -1,7 +1,7 @@
 [
   
   {
-  "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "id": "https://y.com/derived-quality-measurementA",
   "@type": "QualityMeasurement",
   "value": 1,
@@ -17,7 +17,7 @@
 ,
 
 {
-  "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "@id": "https://y.com/quality-measurement-B",
   "@type": "QualityMeasurement",
   "value": "false",
@@ -32,7 +32,7 @@
 }
 ,
   {
-    "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://y.com/products/uk-bonds",
     "type": "DataProduct",
     "outputPort": {

--- a/examples/data-schema/example.jsonld
+++ b/examples/data-schema/example.jsonld
@@ -1,5 +1,5 @@
 {
-"@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+"@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
 "id": "https://y.com/products/equity-trade-xxx",
 "@type": "DataProduct",
 "title": "Equity Trade XXX",

--- a/examples/dprod-example.json
+++ b/examples/dprod-example.json
@@ -1,6 +1,6 @@
 [
   {
-    "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/permid-data-product",
     "type": "DataProduct",
     "title": "PermId Data Product",
@@ -28,7 +28,7 @@
     }
   },
   {
-    "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/gleif-data-product",
     "type": "DataProduct",
     "title": "GLEIF Data Product",
@@ -73,7 +73,7 @@
   },
 
     {
-    "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/legal-entity-data-product",
     "type": "DataProduct",
     "title": "Legal Entity Data Product",

--- a/examples/equity-trade/example.jsonld
+++ b/examples/equity-trade/example.jsonld
@@ -1,5 +1,5 @@
 {
-"@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+"@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
 "id":  "equity trade-xxx",
 "@id": "https://y.com/products/equity-trade-xxx",
 "@type": "DataProduct",

--- a/examples/observability-ports/README.md
+++ b/examples/observability-ports/README.md
@@ -32,7 +32,7 @@ Here is an example of a data product with an observability port:
 
 ```json
 {
-  "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "dataProducts": [
     {
       "id": "https://y.com/data-product/uk-bonds",

--- a/examples/sba-pool-rates/example.jsonld
+++ b/examples/sba-pool-rates/example.jsonld
@@ -1,4 +1,4 @@
-{  "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+{  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "id":  "sba-pool-rates",
   "@id": "https://y.com/products/sba-pool-rates",
   "@type": "DataProduct",

--- a/respec/template.html
+++ b/respec/template.html
@@ -89,8 +89,12 @@
               href: "dprod.ttl",
             },
             {
-              value: "DPROD Ontology --- JSON-LD",
+              value: "DPROD JSON-LD Context",
               href: "dprod.jsonld",
+            },
+            {
+              value: "DPROD Ontology --- JSON-LD",
+              href: "dprod-ontology.jsonld",
             },
             {
               value: "DPROD Ontology --- RDF/XML",
@@ -766,7 +770,7 @@
 
   <pre id="eg12" class="example hljs json ekgfexample">
   {
-    "@context": "https://www.omg.org/spec/DPROD/dprod-context.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://y.com/products/uk-bonds",
     "type": "DataProduct",
     "title": "UK Bonds",

--- a/spec-generator/main.py
+++ b/spec-generator/main.py
@@ -25,6 +25,38 @@ def add_to_context(g, node_shape_iri, node_shapes: dict):
         PropertyShape(node_shape=node_shape, shape_iri=property_shape_iri, g=g)
 
 
+def generate_jsonld_context(g_ontology):
+    """
+    Generate a proper JSON-LD context from the ontology.
+    This creates a context that maps term names to their full URIs.
+    """
+    context = {
+        "@version": 1.1,
+        "id": "@id",
+        "type": "@type",
+        "dprod": ontology_namespace_iri,
+        "xsd": str(XSD),
+        "owl": str(OWL),
+        "dcat": str(DCAT),
+        "dct": str(DCTERMS),
+        "prov": str(PROV),
+        "rdfs": str(RDFS),
+        "rdf": str(RDF),
+        "sh": str(SH),
+        "linkedin": str(LINKEDIN),
+    }
+    
+    # Extract all classes and properties from the ontology
+    for subject in g_ontology.subjects():
+        if str(subject).startswith(ontology_namespace_iri):
+            # Get the local name (term) from the URI
+            term = str(subject).replace(ontology_namespace_iri, "")
+            if term:  # Skip the base URI itself
+                context[term] = f"dprod:{term}"
+    
+    return context
+
+
 def main():
     print("Generating the specification...")
 
@@ -94,8 +126,16 @@ def main():
         "linkedin": str(LINKEDIN),
     }
 
+    # Generate proper JSON-LD context with term mappings
+    proper_context = generate_jsonld_context(g_ontology)
+
     with open('dist/dprod.jsonld', mode='x', encoding='utf-8') as f:
-        print(f"Generating RDF JSON-LD - on its own: ./{f.name}")
+        print(f"Generating JSON-LD context: ./{f.name}")
+        json.dump({"@context": proper_context}, f, indent=4)
+        f.write('\n')
+
+    with open('dist/dprod-ontology.jsonld', mode='x', encoding='utf-8') as f:
+        print(f"Generating OWL ontology as JSON-LD: ./{f.name}")
         f.write(g_ontology.serialize(
             format='json-ld',
             base=ontology_namespace_iri,
@@ -103,11 +143,6 @@ def main():
             context=jsonld_context_ontology,
             auto_compact=True
         ))
-
-    with open('dist/dprod-context.jsonld', mode='x', encoding='utf-8') as f:
-        print(f"Generating JSON-LD context: ./{f.name}")
-        json.dump({"@context": jsonld_context_ontology}, f, indent=4)
-        f.write('\n')
 
     with open('dist/dprod-all.jsonld', mode='x', encoding='utf-8') as f:
         print(f"Generating RDF JSON-LD - all: ./{f.name}")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,101 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from rdflib import Dataset, Namespace, RDF
+from pyld import jsonld
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST = ROOT / "dist"
+GENERATOR = ROOT / "spec-generator" / "main.py"
+
+DPROD_NS = "https://www.omg.org/spec/DPROD/"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def build_dist():
+    """Ensure dist artifacts are generated before tests run."""
+    import subprocess, sys
+    subprocess.check_call([sys.executable, str(GENERATOR)], cwd=str(ROOT))
+    assert (DIST / "dprod.jsonld").exists()
+    assert (DIST / "dprod-ontology.jsonld").exists()
+
+
+def test_dprod_jsonld_is_context():
+    """dprod.jsonld must be a pure JSON-LD context document."""
+    data = json.loads((DIST / "dprod.jsonld").read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    assert set(data.keys()) == {"@context"}
+
+    ctx = data["@context"]
+    assert isinstance(ctx, dict)
+    # Expected namespace prefixes
+    for key in ["dprod", "rdf", "rdfs", "xsd", "dcat", "dct", "sh"]:
+        assert key in ctx, f"Missing prefix: {key}"
+    # JSON-LD keyword aliases
+    assert ctx.get("id") == "@id"
+    assert ctx.get("type") == "@type"
+    # At least one DPROD term mapping
+    assert any(
+        k for k, v in ctx.items()
+        if isinstance(v, str) and v.startswith("dprod:")
+    )
+
+
+def test_ontology_jsonld_contains_graph():
+    """dprod-ontology.jsonld must be an ontology dump with @graph."""
+    data = json.loads((DIST / "dprod-ontology.jsonld").read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    assert "@graph" in data
+
+
+def test_context_resolves_dprod_terms():
+    """A minimal JSON-LD instance using the context must expand to correct triples."""
+    data = json.loads((DIST / "dprod.jsonld").read_text(encoding="utf-8"))
+    context = data["@context"]
+
+    instance = {
+        "@context": context,
+        "@id": "https://example.org/products/demo",
+        "@type": "DataProduct",
+        "dataProductOwner": "https://example.org/people/alice",
+    }
+
+    nquads = jsonld.to_rdf(instance, options={"format": "application/n-quads"})
+
+    ds = Dataset()
+    ds.parse(data=nquads, format="nquads")
+
+    dprod = Namespace(DPROD_NS)
+
+    # rdf:type must resolve to dprod:DataProduct
+    assert (None, RDF.type, dprod.DataProduct) in ds
+    # dprod:dataProductOwner triple must exist
+    assert (None, dprod.dataProductOwner, None) in ds
+
+    subj = next(iter(ds.subjects(predicate=dprod.dataProductOwner)))
+    assert str(subj) == "https://example.org/products/demo"
+
+
+def test_context_id_type_aliases():
+    """Bare 'id' and 'type' must work as aliases for @id and @type."""
+    data = json.loads((DIST / "dprod.jsonld").read_text(encoding="utf-8"))
+    context = data["@context"]
+
+    instance = {
+        "@context": context,
+        "id": "https://example.org/products/alias-test",
+        "type": "DataProduct",
+    }
+
+    nquads = jsonld.to_rdf(instance, options={"format": "application/n-quads"})
+
+    ds = Dataset()
+    ds.parse(data=nquads, format="nquads")
+
+    dprod = Namespace(DPROD_NS)
+
+    assert (None, RDF.type, dprod.DataProduct) in ds
+    subj = next(iter(ds.subjects(predicate=RDF.type)))
+    assert str(subj) == "https://example.org/products/alias-test"


### PR DESCRIPTION
## Summary

- **`dprod.jsonld`** is now a proper JSON-LD context document — it contains only an `@context` object with namespace prefixes, DPROD term mappings (classes and properties extracted from the ontology), and `id`/`type` aliases for `@id`/`@type`.
- **`dprod-ontology.jsonld`** is the OWL ontology serialized as JSON-LD (what `dprod.jsonld` previously was).
- All example `@context` references updated from `dprod-context.jsonld` to `dprod.jsonld`.
- Other generated artifacts (`dprod-all.jsonld`, `*.ttl`, `*.rdf`, shapes) remain unchanged.

Resolves #93

## What changed

- **Generator** (`spec-generator/main.py`):
  - New `generate_jsonld_context()` function extracts all DPROD term names from the ontology graph and maps them to `dprod:` prefixed terms.
  - Context includes `"id": "@id"` and `"type": "@type"` aliases for convenience.
  - Writes the context to `dist/dprod.jsonld`.
  - Writes the ontology dump to `dist/dprod-ontology.jsonld`.
  - Removes `dprod-context.jsonld` (no longer needed).
- **Spec template** (`respec/template.html`):
  - Download links: added "DPROD JSON-LD Context" (`dprod.jsonld`) and "DPROD Ontology — JSON-LD" (`dprod-ontology.jsonld`).
  - Inline example `@context` updated to `dprod.jsonld`.
- **Examples**: All `@context` references changed from `dprod-context.jsonld` to `dprod.jsonld`.
- **Tests** (`tests/test_context.py`):
  - `dprod.jsonld` is a pure context (only `@context` key, includes prefixes and term mappings).
  - `dprod-ontology.jsonld` contains `@graph`.
  - Minimal JSON-LD instance using the context expands to correct DPROD triples via PyLD.
  - Bare `id`/`type` aliases resolve correctly.
- **CLAUDE.md**: Updated documentation to reflect new file layout.

## How to consume

Reference the context in JSON-LD instance documents:
```json
"@context": "https://www.omg.org/spec/DPROD/dprod.jsonld"
```

## Verification

- Local build: Python 3.13, `.venv`
- Test run: 4 tests passed, 0 failures