### PR TITLE
Use dct:title for DataProduct and Dataset shapes; require Python 3.13

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ REPO_DIR="$(dirname "$(realpath ${BASH_SOURCE[0]})")"
 venv_dir="${REPO_DIR}/.venv"
 system_python_bin="/usr/bin/python3"
 system_python_version="0.0.0"
-system_python_minimum_version="3.12"
+system_python_minimum_version="3.13"
 venv_python_bin="${venv_dir}/bin/python${system_python_minimum_version}"
 
 function check_system_python() {

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -61,7 +61,7 @@ dprod-shapes:DataProductShape
     rdfs:isDefinedBy dprod-shapes:;
     rdfs:label "data product shape" ;
     sh:targetClass dprod:DataProduct;
-    sh:property dprod-shapes:DataProduct-label;
+    sh:property dprod-shapes:DataProduct-title;
     sh:property dprod-shapes:DataProduct-description;
     sh:property dprod-shapes:DataProduct-dataProductOwner;
     sh:property dprod-shapes:DataProduct-domain;
@@ -105,7 +105,7 @@ dprod-shapes:DatasetShape
   rdfs:label "dataset shape" ;
   dct:description "A collection of data, published or curated by a single source, and available for access or download in one or more representations."@en ;
   sh:targetClass dcat:Dataset ;
-  sh:property dprod-shapes:Dataset-label;
+  sh:property dprod-shapes:Dataset-title;
   sh:property dprod-shapes:Dataset-description;
   sh:property dprod-shapes:Dataset-type;
   sh:property dprod-shapes:Dataset-distribution ;
@@ -148,13 +148,13 @@ dprod-shapes:SecuritySchemaTypeShape
 
 #############################  dprod Property Shapes ################
 
-dprod-shapes:DataProduct-label
+dprod-shapes:DataProduct-title
   a sh:PropertyShape;
   rdfs:isDefinedBy dprod-shapes:;
-  sh:path rdfs:label;
+  sh:path dct:title;
   sh:datatype xsd:string;
-  dct:description "The name given to the data product."@en ;
-  rdfs:label "data product label shape";
+  dct:description "The title given to the data product."@en ;
+  rdfs:label "data product title shape";
 .
 
 dprod-shapes:DataProduct-description
@@ -255,13 +255,13 @@ dprod-shapes:DataProduct-outputDataset
   rdfs:label "data product output dataset shape";
 .
 
-dprod-shapes:Dataset-label
+dprod-shapes:Dataset-title
   a sh:PropertyShape;
   rdfs:isDefinedBy dprod-shapes:;
-  sh:path rdfs:label;
+  sh:path dct:title;
   sh:datatype xsd:string ;
-  dct:description "The name given to the dataset"@en ;
-  rdfs:label "dataset label shape" ;
+  dct:description "The title given to the dataset."@en ;
+  rdfs:label "dataset title shape" ;
  .
 
 dprod-shapes:Dataset-description

--- a/spec-generator/main.py
+++ b/spec-generator/main.py
@@ -64,18 +64,17 @@ def main():
     g_shapes = load_dprod_shapes()
     
     jsonld_context_ontology = {
-<<<<<<< HEAD
-            "@version": 1.1,
-            "dprod": ontology_namespace_iri,
-            "xsd": str(XSD),
-            "owl": str(OWL),
-            "dcat": str(DCAT),
-            "dct": str(DCTERMS),
-            "prov": str(PROV),
-            "rdfs": str(RDFS),
-            "rdf": str(RDF),
-            "sh": str(SH),
-            "linkedin": str(LINKEDIN)
+        "@version": 1.1,
+        "dprod": ontology_namespace_iri,
+        "xsd": str(XSD),
+        "owl": str(OWL),
+        "dcat": str(DCAT),
+        "dct": str(DCTERMS),
+        "prov": str(PROV),
+        "rdfs": str(RDFS),
+        "rdf": str(RDF),
+        "sh": str(SH),
+        "linkedin": str(LINKEDIN)
     }
 
     jsonld_context_shapes = {


### PR DESCRIPTION
This PR addresses part of ontology issue #98 by aligning shapes with DCAT conventions:

- Replace rdfs:label with dct:title on DataProduct and Dataset shapes
- Update NodeShapes to reference the new PropertyShapes
- Upgrade build to Python 3.13 (Actions already uses 3.13)

Refs #98

Fixes #140