### PR TITLE
ci: auto-add issues/PRs to org project #5

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,18 @@
+name: Auto add issues and PRs to EKGF Data Product Workgroup project
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to org project
+        uses: actions/add-to-project@v1.0.1
+        with:
+          project-url: https://github.com/orgs/EKGF/projects/5
+          github-token: ${{ secrets.PROJECTS_WRITE_TOKEN }}
+


### PR DESCRIPTION
Adds a workflow to automatically add newly opened issues and pull requests to the EKGF Data Product Workgroup project (project #5) via actions/add-to-project.\n\nConfiguration:\n- Requires repo secret: PROJECTS_WRITE_TOKEN with access to org projects (write).\n\nThis will keep the project up-to-date without manual triage.