### PR TITLE
examples: normalize JSON-LD structure in data-quality example

### DIFF
--- a/examples/data-quality/example.jsonld
+++ b/examples/data-quality/example.jsonld
@@ -1,50 +1,46 @@
-[
-  
-  {
-  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
-  "id": "https://y.com/derived-quality-measurementA",
-  "@type": "QualityMeasurement",
-  "value": 1,
-  "computedOn": {
-      "@type": "DataProduct",
-      "@id": "https://y.com/products/uk-bonds"
-    },
-  "isMeasurementOf": {
-    "@type": "Metric",
-    "label": "Number of stale datasets"
-    }
-}
-,
-
 {
   "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
-  "@id": "https://y.com/quality-measurement-B",
-  "@type": "QualityMeasurement",
-  "value": "false",
-  "computedOn": {
-      "@type": "Dataset",
-      "@id": "https://y.com/products/uk-bonds/yearlyPrices"
+  "@graph": [
+    {
+      "@id": "https://y.com/derived-quality-measurementA",
+      "@type": "QualityMeasurement",
+      "value": 1,
+      "computedOn": {
+        "@type": "DataProduct",
+        "@id": "https://y.com/products/uk-bonds"
+      },
+      "isMeasurementOf": {
+        "@type": "Metric",
+        "label": "Number of stale datasets"
+      }
     },
-  "isMeasurementOf": {
-    "@type": "Metric",
-    "label": "Expected distribution frequency achieved"
-  }
-}
-,
-  {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
-    "id": "https://y.com/products/uk-bonds",
-    "type": "DataProduct",
-    "outputPort": {
-      "type": "DataService",
-      "endpointURL": "https://y.com/uk-bonds/quality-report",
-      "isAccessServiceOf": {
-        "type": "Distribution",
-        "isDistributionOf": {
-          "type": "Dataset",
-          "conformsTo": "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"
+    {
+      "@id": "https://y.com/quality-measurement-B",
+      "@type": "QualityMeasurement",
+      "value": "false",
+      "computedOn": {
+        "@type": "Dataset",
+        "@id": "https://y.com/products/uk-bonds/yearlyPrices"
+      },
+      "isMeasurementOf": {
+        "@type": "Metric",
+        "label": "Expected distribution frequency achieved"
+      }
+    },
+    {
+      "@id": "https://y.com/products/uk-bonds",
+      "@type": "DataProduct",
+      "outputPort": {
+        "@type": "DataService",
+        "endpointURL": "https://y.com/uk-bonds/quality-report",
+        "isAccessServiceOf": {
+          "@type": "Distribution",
+          "isDistributionOf": {
+            "@type": "Dataset",
+            "conformsTo": "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"
+          }
         }
       }
     }
-  }
-]
+  ]
+}


### PR DESCRIPTION
This PR addresses and closes #119 by normalizing the JSON-LD structure in the data-quality example:\n\n- Single top-level @context (use published DPROD context)\n- Move multiple nodes into @graph\n- Consistent use of JSON-LD keywords (@id, @type)\n\nThis should satisfy RIOT validation and align examples with the fixed context model from #93 / PR #135.