### PR TITLE
examples: adjust DQV modeling in data-quality example

### DIFF
--- a/examples/data-quality/example.jsonld
+++ b/examples/data-quality/example.jsonld
@@ -42,7 +42,7 @@
         "type": "Distribution",
         "isDistributionOf": {
           "type": "Dataset",
-          "conformsTo": "https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement"
+          
         }
       }
     }


### PR DESCRIPTION
This PR addresses #91 by removing the incorrect use of dct:conformsTo to DQV on a Dataset.\n\n- Keep explicit dqv:QualityMeasurement instances to represent quality metrics\n- Avoid asserting that a Dataset "conforms to" DQV (a vocabulary)\n\nThis complements the structural fixes from #119 / PR #149 and should make the example clearer in JSON-LD tooling.