### PR TITLE
chore: add formatting and linting configuration

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "MD013": {
+    "line_length": 70,
+    "heading_line_length": 70,
+    "code_block_line_length": 9999
+  },
+  "MD025": {
+    "front_matter_title": ""
+  }
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,18 @@
+{
+  "printWidth": 70,
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 70,
+        "proseWrap": "always",
+        "endOfLine": "lf"
+      }
+    }
+  ],
+  "plugins": [
+    "./.scripts/prettier-plugin-strip-nbsp.js"
+  ],
+  "endOfLine": "lf"
+}

--- a/.scripts/prettier-plugin-strip-nbsp.js
+++ b/.scripts/prettier-plugin-strip-nbsp.js
@@ -1,0 +1,32 @@
+// Prettier plugin to strip trailing non-breaking spaces from markdown files
+const markdown = require('prettier/parser-markdown');
+
+module.exports = {
+  parsers: {
+    markdown: {
+      ...markdown.parsers.markdown,
+      parse(text, parsers, options) {
+        // Remove trailing non-breaking spaces (U+00A0) and other Unicode whitespace at end of lines
+        // This handles both lines that end with non-breaking spaces and lines that are entirely non-breaking spaces
+        let cleaned = text
+          // Remove trailing Unicode whitespace (non-breaking spaces, etc.) at end of lines
+          .replace(/[\u00A0\u2000-\u200B\u202F\u205F\u3000]+$/gm, '')
+          // Also remove lines that are entirely Unicode whitespace (non-breaking spaces)
+          .replace(/^[\u00A0\u2000-\u200B\u202F\u205F\u3000]+\n/gm, '\n');
+
+        // Convert leading non-breaking spaces to regular spaces
+        // This fixes formatting issues where NBSP at the start of lines prevents proper paragraph/list formatting
+        cleaned = cleaned.replace(/^([\u00A0\u2000-\u200B\u202F\u205F\u3000]+)/gm, (match) => ' '.repeat(match.length));
+
+        // Convert non-breaking spaces before markdown list markers to regular spaces
+        // This fixes formatting issues where NBSP prevents proper list item recognition
+        cleaned = cleaned.replace(/([\s]*)[\u00A0\u2000-\u200B\u202F\u205F\u3000]+([-*+]\s)/gm, '$1$2');
+
+        // Use the original markdown parser
+        return markdown.parsers.markdown.parse(cleaned, parsers, options);
+      },
+    },
+  },
+  printers: markdown.printers,
+  languages: markdown.languages,
+};

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "makefile.configureOnOpen": false
+  "makefile.configureOnOpen": false,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  }
 }
-
-


### PR DESCRIPTION
## Summary
- Add `.markdownlint.json` for markdown line length rules (70 chars)
- Add `.prettierrc.json` with 70 char width and prose wrapping
- Add custom prettier plugin (`.scripts/prettier-plugin-strip-nbsp.js`) to strip non-breaking spaces from markdown
- Update `.vscode/settings.json` to trim trailing whitespace (except in markdown)

## Test plan
- [ ] Verify prettier formats markdown files correctly
- [ ] Verify markdownlint rules are applied in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)