### PR TITLE
Ballot 2: use OMG URI namespace (DPROD-22)

### DIFF
--- a/examples/core-data-product-extensions/README.md
+++ b/examples/core-data-product-extensions/README.md
@@ -12,7 +12,7 @@ In this example, a Data Product Agreement is defined as a subclass of FIBO Agree
 [
   {
     "@context": [
-      "https://ekgf.github.io/dprod/dprod.jsonld",
+      "https://www.omg.org/spec/DPROD/dprod.jsonld",
       {
         "fibo": "http://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/#",
         "ex": "http://example.org/dp#"
@@ -50,7 +50,7 @@ Below is an example of a Data Product with an associated Data Product Agreement 
 ```json
 {
   "@context": [
-    "https://ekgf.github.io/dprod/dprod.jsonld",
+    "https://www.omg.org/spec/DPROD/dprod.jsonld",
     {
       "fibo": "http://spec.edmcouncil.org/fibo/ontology/FND/Agreements/MetadataFNDAgreements/#",
       "ex": "http://example.org/dp#"

--- a/examples/data-lineage/README.md
+++ b/examples/data-lineage/README.md
@@ -25,7 +25,7 @@ connect to each other through their input and output ports:
 
 ```json
 {
-  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "dataProducts": [
     {
       "id": "https://y.com/data-product/company-finance",
@@ -119,7 +119,7 @@ In Linked Data, this would use a query such as:
 ```sparql
 PREFIX :      <https://y.com/data-product/>
 PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX dprod: <https://ekgf.github.io/dprod/>
+PREFIX dprod: <https://www.omg.org/spec/DPROD/>
 
 SELECT DISTINCT ?input
 WHERE

--- a/examples/data-quality/example.jsonld
+++ b/examples/data-quality/example.jsonld
@@ -1,7 +1,7 @@
 [
   
   {
-  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "id": "https://y.com/derived-quality-measurementA",
   "@type": "QualityMeasurement",
   "value": 1,
@@ -17,7 +17,7 @@
 ,
 
 {
-  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "@id": "https://y.com/quality-measurement-B",
   "@type": "QualityMeasurement",
   "value": "false",
@@ -32,7 +32,7 @@
 }
 ,
   {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://y.com/products/uk-bonds",
     "type": "DataProduct",
     "outputPort": {

--- a/examples/data-schema/example.jsonld
+++ b/examples/data-schema/example.jsonld
@@ -1,5 +1,5 @@
 {
-"@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+"@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
 "id": "https://y.com/products/equity-trade-xxx",
 "@type": "DataProduct",
 "title": "Equity Trade XXX",

--- a/examples/dprod-example.json
+++ b/examples/dprod-example.json
@@ -1,12 +1,12 @@
 [
   {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/permid-data-product",
     "type": "DataProduct",
     "title": "PermId Data Product",
     "description": "LSEG is making available its Permanent Identifiers, or PermIDs, and the associated entity masters and metadata to the market. PermIDs are open, permanent and universal identifiers where underlying attributes capture the context of the identity they each represent.",
     "dataProductOwner": "https://www.linkedin.com/in/olibage/",
-    "lifecycleStatus": "https://ekgf.github.io/dprod/data/lifecycle-status/Consume",
+    "lifecycleStatus": "https://www.omg.org/spec/DPROD/data/lifecycle-status/Consume",
     "outputPort": {
       "type": "DataService",
        "id": "https://www.ekgf.org/data/dataservice/permid-organization"
@@ -28,13 +28,13 @@
     }
   },
   {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/gleif-data-product",
     "type": "DataProduct",
     "title": "GLEIF Data Product",
     "description": "GLEIF makes available the Global LEI Index. This is the only global online source that provides open, standardized and high quality legal entity reference data. By doing so, GLEIF enables people and businesses to make smarter, less costly and more reliable decisions about who to do business with.",
     "dataProductOwner": "https://www.linkedin.com/in/peterivett/",
-    "lifecycleStatus": "https://ekgf.github.io/dprod/data/lifecycle-status/Consume",
+    "lifecycleStatus": "https://www.omg.org/spec/DPROD/data/lifecycle-status/Consume",
     "outputPort": [
       {
         "type": "DataService",
@@ -73,13 +73,13 @@
   },
 
     {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://www.ekgf.org/data/data-product/legal-entity-data-product",
     "type": "DataProduct",
     "title": "Legal Entity Data Product",
     "description": "TODO",
     "dataProductOwner": "https://www.linkedin.com/in/tonyseale/",
-    "lifecycleStatus": "https://ekgf.github.io/dprod/data/lifecycle-status/Consume",
+    "lifecycleStatus": "https://www.omg.org/spec/DPROD/data/lifecycle-status/Consume",
     "inputPort": [{
                 "type": "DataService",
                 "id": "https://www.ekgf.org/data/dataservice/gleif-l1"

--- a/examples/equity-trade/example.jsonld
+++ b/examples/equity-trade/example.jsonld
@@ -1,5 +1,5 @@
 {
-"@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+"@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
 "id":  "equity trade-xxx",
 "@id": "https://y.com/products/equity-trade-xxx",
 "@type": "DataProduct",

--- a/examples/observability-ports/README.md
+++ b/examples/observability-ports/README.md
@@ -32,7 +32,7 @@ Here is an example of a data product with an observability port:
 
 ```json
 {
-  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "dataProducts": [
     {
       "id": "https://y.com/data-product/uk-bonds",

--- a/examples/sba-pool-rates/example.jsonld
+++ b/examples/sba-pool-rates/example.jsonld
@@ -1,4 +1,4 @@
-{  "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+{  "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
   "id":  "sba-pool-rates",
   "@id": "https://y.com/products/sba-pool-rates",
   "@type": "DataProduct",

--- a/ontology/dprod/.copier-answers.env
+++ b/ontology/dprod/.copier-answers.env
@@ -1,14 +1,14 @@
 # Changes here will be overwritten by Copier
 ONTOLOGY_FILE=dprod
-ONTOLOGY_IRI="https://ekgf.github.io/dprod/"
+ONTOLOGY_IRI="https://www.omg.org/spec/DPROD/"
 ONTOLOGY_PREFIX="dprod:"
-ONTOLOGY_GRAPH_IRI="https://ekgf.github.io/dprod/"
+ONTOLOGY_GRAPH_IRI="https://www.omg.org/spec/DPROD/"
 
 SHAPE=True
 SHAPE_FILE=dprod-sh
-SHAPE_BASE_IRI="https://ekgf.github.io/dprod/shapes"
+SHAPE_BASE_IRI="https://www.omg.org/spec/DPROD/shapes"
 SHAPE_BASE_PREFIX="dprod-sh:"
-SHAPE_GRAPH_IRI="https://ekgf.github.io/dprod/shapes"
+SHAPE_GRAPH_IRI="https://www.omg.org/spec/DPROD/shapes"
 
 INSTANCES=False
 INSTANCES_FILE=instances

--- a/ontology/dprod/.copier-answers.yml
+++ b/ontology/dprod/.copier-answers.yml
@@ -13,13 +13,13 @@ instances_file: instances.ttl
 instances_file_exists: false
 instances_graph_iri: http://data.example.org
 ontology_file: dprod.ttl
-ontology_graph_iri: https://ekgf.github.io/dprod/
-ontology_iri: https://ekgf.github.io/dprod/
+ontology_graph_iri: https://www.omg.org/spec/DPROD/
+ontology_iri: https://www.omg.org/spec/DPROD/
 ontology_prefix: 'dprod:'
 project_name: dprod
 shape: true
-shape_base_iri: https://ekgf.github.io/dprod/shapes
+shape_base_iri: https://www.omg.org/spec/DPROD/shapes
 shape_base_prefix: 'dprod-sh:'
 shape_file: dprod-sh.ttl
-shape_graph_iri: https://ekgf.github.io/dprod/shapes
+shape_graph_iri: https://www.omg.org/spec/DPROD/shapes
 

--- a/ontology/dprod/artifacts/ontology-documentation.html
+++ b/ontology/dprod/artifacts/ontology-documentation.html
@@ -185,7 +185,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">Data Product</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/DataProduct</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/DataProduct</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-3fd577e914168fcd735ac6f9f4518430-nav"
@@ -242,7 +242,7 @@ style="position: -webkit-sticky;
     href="#id-aac2e6805701fcb98713a4b874420bf2"
     >output port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -255,7 +255,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">Port</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/Port</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/Port</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-cff5e0c835fe52b5af0b3e2f356d5d64-nav"
@@ -320,7 +320,7 @@ style="position: -webkit-sticky;
     href="#id-aac2e6805701fcb98713a4b874420bf2"
     >output port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -339,7 +339,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">output port</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/outputPort</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/outputPort</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-aac2e6805701fcb98713a4b874420bf2-nav"
@@ -394,7 +394,7 @@ style="position: -webkit-sticky;
     href="#id-cff5e0c835fe52b5af0b3e2f356d5d64"
     >Port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -407,7 +407,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">promise</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/promise</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/promise</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-5d8646950d547635fdfed15645b3367a-nav"
@@ -459,7 +459,7 @@ style="position: -webkit-sticky;
     href="#id-cff5e0c835fe52b5af0b3e2f356d5d64"
     >Port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -472,7 +472,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">expectation</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/expectation</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/expectation</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-13851b49ce65c8ab97d19fd3f817d1dc-nav"
@@ -524,7 +524,7 @@ style="position: -webkit-sticky;
     href="#id-cff5e0c835fe52b5af0b3e2f356d5d64"
     >Port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -537,7 +537,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">contract</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/contract</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/contract</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-b7e23ed19ca21a66081fce7811c063b3-nav"
@@ -589,7 +589,7 @@ style="position: -webkit-sticky;
     href="#id-cff5e0c835fe52b5af0b3e2f356d5d64"
     >Port</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -605,7 +605,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">fully qualified name</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/fullyQualifiedName</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/fullyQualifiedName</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-151b8c269d8a4f85e919be0d4f630519-nav"
@@ -660,7 +660,7 @@ style="position: -webkit-sticky;
     href="#id-4e598fd1b2c9ef9bd360334e0ef7610a"
     >string</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>
@@ -673,7 +673,7 @@ style="position: -webkit-sticky;
     >
     <div class="card-header">
         <h4 class="card-title">domain</h4>
-        <p><small class="text-muted">https://ekgf.github.io/dprod/domain</small></p>
+        <p><small class="text-muted">https://www.omg.org/spec/DPROD/domain</small></p>
         <nav
             class="nav nav-tabs card-header-tabs"
             id="id-abf8102a2e563f744245a507e8adfdfb-nav"
@@ -728,7 +728,7 @@ style="position: -webkit-sticky;
     href="#id-4e598fd1b2c9ef9bd360334e0ef7610a"
     >string</a>
 </dd><dt>is defined by</dt>
-                <dd>https://ekgf.github.io/dprod/</dd></dl>
+                <dd>https://www.omg.org/spec/DPROD/</dd></dl>
         </div>
     </div>
     <div class="card-footer"></div>

--- a/ontology/dprod/dprod-ontology.ttl
+++ b/ontology/dprod/dprod-ontology.ttl
@@ -1,9 +1,9 @@
-# baseURI: https://ekgf.github.io/dprod/
+# baseURI: https://www.omg.org/spec/DPROD/
 # imports: http://www.w3.org/ns/dcat#
 # prefix: dprod
 
-@base <https://ekgf.github.io/dprod/> .
-@prefix dprod: <https://ekgf.github.io/dprod/> .
+@base <https://www.omg.org/spec/DPROD/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -1,13 +1,13 @@
-# baseURI: https://ekgf.github.io/dprod/shapes/
+# baseURI: https://www.omg.org/spec/DPROD/shapes/
 # imports: http://www.w3.org/ns/dcat#
 # imports: http://www.w3.org/ns/shacl#
-# imports: https://ekgf.github.io/dprod/
+# imports: https://www.omg.org/spec/DPROD/
 # prefix: dprod-shapes
 
 
-@base <https://ekgf.github.io/dprod/shapes/> .
-@prefix dprod-shapes: <https://ekgf.github.io/dprod/shapes/> .
-@prefix dprod: <https://ekgf.github.io/dprod/> .
+@base <https://www.omg.org/spec/DPROD/shapes/> .
+@prefix dprod-shapes: <https://www.omg.org/spec/DPROD/shapes/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix odrl:	<http://www.w3.org/ns/odrl/2/>.
@@ -40,11 +40,11 @@ dprod-shapes:
   owl:versionInfo "OMG Request For Comments Errata 2" ;
   sh:declare [
     sh:prefix "dprod" ;
-    sh:namespace "https://ekgf.github.io/dprod/" ;
+    sh:namespace "https://www.omg.org/spec/DPROD/" ;
    ] ;
   sh:declare [
     sh:prefix "dprod-shapes" ;
-    sh:namespace "https://ekgf.github.io/dprod/shapes/" ;
+    sh:namespace "https://www.omg.org/spec/DPROD/shapes/" ;
   ] ;
   sh:declare [
     sh:prefix "dcat" ;

--- a/respec/template.html
+++ b/respec/template.html
@@ -11,7 +11,7 @@
     const respecConfig = {
       // Working Groups ids at https://respec.org/w3c/groups/
       // group: "Semantic Data Products Working Group",
-      latestVersion: "https://ekgf.github.io/dprod/",
+      latestVersion: "https://www.omg.org/spec/DPROD/",
       specStatus: "base",
       editors: [
         {
@@ -131,7 +131,7 @@
         },
         dprod: {
           title: "Data Product Ontology",
-          href: "https://ekgf.github.io/dprod/",
+          href: "https://www.omg.org/spec/DPROD/",
           authors: [
             "Tony Seale",
             "Natasa Varytimou",
@@ -439,7 +439,7 @@
 <section>
   <h2>Scope</h2>
   <p>
-    The <a href="https://ekgf.github.io/dprod/dprod.ttl">Data Product (DPROD)</a> specification is a
+    The <a href="https://www.omg.org/spec/DPROD/dprod.ttl">Data Product (DPROD)</a> specification is a
     profile of the <a href="https://www.w3.org/TR/vocab-dcat-3/">Data Catalog (DCAT) Vocabulary</a>,
     designed to describe Data Products.
     This document defines the schema and provides examples of its use.
@@ -452,7 +452,7 @@
     and enables federated search across multiple sites using a uniform query mechanism and structure.
   </p>
   <p>
-    The namespace for DPROD terms is <a href="https://ekgf.github.io/dprod/">https://ekgf.github.io/dprod/</a>
+    The namespace for DPROD terms is <a href="https://www.omg.org/spec/DPROD/">https://www.omg.org/spec/DPROD/</a>
   </p>
   <p>
     The suggested prefix for the DPROD namespace is <strong><code>dprod</code></strong>
@@ -466,7 +466,7 @@
     </li>
     <li>
       Harmonize Data Schemas: Using shared schemas helps unify different data formats.
-      For instance, the <a href="https://ekgf.github.io/dprod/dprod.ttl">DPROD</a> specification provides a
+      For instance, the <a href="https://www.omg.org/spec/DPROD/dprod.ttl">DPROD</a> specification provides a
       <!--suppress HtmlUnknownAnchorTarget -->
       common set of rules for defining a <a href="#dataproduct">Data Product</a>.
       Users of DPROD can extend this schema as needed.
@@ -593,7 +593,7 @@
         <code>dprod</code>
       </td>
       <td>
-        <code>https://ekgf.github.io/dprod/</code>
+        <code>https://www.omg.org/spec/DPROD/</code>
       </td>
       <td>[[dprod]]</td>
     </tr>
@@ -767,13 +767,13 @@
 
   <pre id="eg12" class="example hljs json ekgfexample">
   {
-    "@context": "https://ekgf.github.io/dprod/dprod.jsonld",
+    "@context": "https://www.omg.org/spec/DPROD/dprod.jsonld",
     "id": "https://y.com/products/uk-bonds",
     "type": "DataProduct",
     "title": "UK Bonds",
     "description": "UK Bonds is your one-stop-shop for all your bonds!",
     "dataProductOwner": "https://www.linkedin.com/in/tonyseale/",
-    "lifecycleStatus" : "https://ekgf.github.io/dprod/data/lifecycle-status/Consume",
+    "lifecycleStatus" : "https://www.omg.org/spec/DPROD/data/lifecycle-status/Consume",
     "outputPort": {
       "type": "DataService",
       "endpointURL": "https://y.com/uk-10-year-bonds",

--- a/spec-generator/globals.py
+++ b/spec-generator/globals.py
@@ -3,9 +3,9 @@ from rdflib import Namespace, RDF, RDFS, SH, SKOS, OWL, XSD, DCAT, DCTERMS
 debug = False
 show_source = False
 
-ontology_namespace_iri = "https://ekgf.github.io/dprod/"
+ontology_namespace_iri = "https://www.omg.org/spec/DPROD/"
 DPROD = Namespace(ontology_namespace_iri)
-shapes_graph_ns_iri = "https://ekgf.github.io/dprod/shapes/"
+shapes_graph_ns_iri = "https://www.omg.org/spec/DPROD/shapes/"
 DPROD_SHAPES = Namespace(shapes_graph_ns_iri)
 
 linkedin_ns_iri = "https://www.linkedin.com/in/"

--- a/spec-generator/main.py
+++ b/spec-generator/main.py
@@ -64,7 +64,6 @@ def main():
     g_shapes = load_dprod_shapes()
     
     jsonld_context_ontology = {
-<<<<<<< HEAD
             "@version": 1.1,
             "dprod": ontology_namespace_iri,
             "xsd": str(XSD),


### PR DESCRIPTION
## Ballot 2

This ballot contains a single issue resolution:

### Included Issues
- **DPROD-22** (GitHub #118): Use OMG URI namespace instead of github.io

### Summary
- Update all namespace URIs from `https://ekgf.github.io/dprod/` to `https://www.omg.org/spec/DPROD/`
- Affects ontology, shapes, all JSON-LD examples, spec generator, and documentation templates

### Files changed (16)
- `ontology/dprod/dprod-ontology.ttl` — ontology namespace
- `ontology/dprod/dprod-shapes.ttl` — shapes namespace
- `spec-generator/globals.py` — namespace constants
- `spec-generator/main.py` — removed stray merge conflict marker
- `respec/template.html` — documentation template URIs
- `ontology/dprod/.copier-answers.{yml,env}` — copier config
- `ontology/dprod/artifacts/ontology-documentation.html` — generated docs
- All JSON-LD examples updated to new namespace

### Review Instructions
Please review the namespace changes to ensure all URIs correctly use `https://www.omg.org/spec/DPROD/` as the base namespace for the DPROD ontology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)