### PR TITLE
ci: auto-label PRs from ballot/* branches

### DIFF
--- a/.github/workflows/auto-label-ballot.yml
+++ b/.github/workflows/auto-label-ballot.yml
@@ -1,0 +1,18 @@
+name: Auto-label ballot PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  label:
+    if: startsWith(github.head_ref, 'ballot/')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add OMG Ballot label
+        run: gh pr edit "$PR_NUMBER" --add-label "OMG Ballot"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Adds a workflow that automatically applies the "OMG Ballot" label to PRs opened from `ballot/*` branches
- Uses `GITHUB_TOKEN` (no additional secrets needed)

## Test plan
- [ ] Open a PR from a `ballot/*` branch and verify the label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)