### PR TITLE
Add adalbert-contracts: ODRL 2.2 profile for data governance

### DIFF
--- a/adalbert-contracts/README.md
+++ b/adalbert-contracts/README.md
@@ -1,0 +1,177 @@
+# Adalbert: Data Contracts and Data-Use Policies
+
+**An ODRL 2.2 profile with deterministic evaluation semantics for data governance.**
+
+Adalbert provides a formal, standards-based approach to data contracts and data-use policies. It uses ODRL 2.2 terms for all standard constructs and adds only genuinely new extensions for lifecycle management, bilateral duties, recurrence, and structured operand resolution.
+
+---
+
+## What This Is
+
+This folder contains the Adalbert data governance framework as a contribution to EKGF/dprod, complementing the `dprod-contracts` approach with:
+
+1. **Data contracts** — bilateral agreements between data providers and consumers (like dprod-contracts)
+2. **Data-use policies** — organizational access controls, purpose restrictions, classification rules (unique to Adalbert)
+3. **Formal semantics** — normative evaluation specification amenable to formal verification
+4. **ODRL 2.2 compliance** — every Adalbert policy is a valid ODRL 2.2 policy
+
+## Key Differentiators
+
+| Capability | dprod-contracts | Adalbert |
+|---|---|---|
+| Data contracts | Yes | Yes |
+| Data-use policies | No | **Yes** |
+| Formal semantics | No | **Yes** (normative, verification-ready) |
+| Bilateral duties | Via Promise subclass | **Via standard odrl:Duty** |
+| Lifecycle states | Status enum | **Formal state machine** (Pending → Active → Fulfilled/Violated) |
+| Recurrence | ICalSchedule class | **RRULE property** + deadline window |
+| Operand resolution | Unspecified | **Structured paths** (agent.role, asset.classification, context.purpose) |
+| Constraint vocabulary | Minimal | **33 operands** across 15 categories |
+| ODRL compatibility | Custom Rule subclass | **Standard Rule types** (Permission, Duty, Prohibition) |
+
+---
+
+## Folder Contents
+
+```
+adalbert-contracts/
+├── README.md                          # This file
+├── adalbert-core.ttl                  # OWL ontology (ODRL profile extension)
+├── adalbert-shacl.ttl                 # SHACL validation shapes
+├── adalbert-prof.ttl                  # W3C DXPROF profile metadata
+├── adalbert-due.ttl                   # Data use vocabulary (operands, actions, values)
+├── examples/
+│   ├── data-contract.ttl              # Bilateral contract with provider SLA + consumer duties
+│   ├── data-use-policy.ttl            # Role-based access control with purpose constraints
+│   ├── dprod-translated.ttl           # dprod-contracts examples translated to Adalbert
+│   └── baseline.ttl                   # Comprehensive test suite (8 contracts, 2 subscriptions)
+└── docs/
+    ├── DATA-CONTRACTS.md              # Data contract authoring guide
+    ├── DATA-USE-POLICIES.md           # Data-use policy authoring guide
+    ├── SPECIFICATION.md               # Technical vocabulary reference
+    ├── SEMANTICS.md                   # Formal evaluation semantics (normative)
+    └── DPROD-Adalbert-Comparison.md   # Comparison with dprod-contracts
+```
+
+---
+
+## Quick Start
+
+### Data Contract (bilateral agreement)
+
+```turtle
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:marketPrices ;
+    adalbert:state adalbert:Active ;
+
+    # Provider SLA: daily delivery with 30-min window
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # Consumer: may read
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: must report monthly
+    odrl:obligation [
+        a odrl:Duty ;
+        odrl:action adalbert-due:report ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # No redistribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] .
+```
+
+### Data-Use Policy (organizational access control)
+
+```turtle
+ex:policy a odrl:Set ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:target ex:employeeData ;
+
+    # HR Analytics: read for analytics purpose only
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee ex:hrAnalytics ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:analytics
+        ]
+    ] ;
+
+    # No ML training on employee data
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:use ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:processingMode ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:modelTraining
+        ]
+    ] .
+```
+
+---
+
+## Relationship to dprod-contracts
+
+Adalbert and dprod-contracts are complementary approaches to the same problem space. See `docs/DPROD-Adalbert-Comparison.md` for a detailed comparison and `examples/dprod-translated.ttl` for all 8 dprod-contracts examples expressed in Adalbert.
+
+Key architectural difference: dprod-contracts introduces `dprod:Promise` as a new `odrl:Rule` subclass. Adalbert uses standard `odrl:Duty`, `odrl:Permission`, and `odrl:Prohibition`, making every Adalbert policy a valid ODRL 2.2 policy that any ODRL processor can partially understand.
+
+---
+
+## SHACL Validation
+
+Validate any Adalbert policy against the SHACL shapes:
+
+```bash
+shacl validate --shapes adalbert-shacl.ttl --data examples/data-contract.ttl
+```
+
+---
+
+## Namespaces
+
+| Prefix | Namespace | Role |
+|--------|-----------|------|
+| `odrl:` | `http://www.w3.org/ns/odrl/2/` | Primary — all standard ODRL constructs |
+| `adalbert:` | `https://vocabulary.bigbank/adalbert/` | Extensions only (State, deadline, recurrence, DataContract, Subscription) |
+| `adalbert-due:` | `https://vocabulary.bigbank/adalbert/due/` | Data use vocabulary (operands, actions, concept values) |
+
+---
+
+## References
+
+- [ODRL 2.2 Information Model](https://www.w3.org/TR/odrl-model/)
+- [W3C ODRL Profile Best Practices](https://www.w3.org/community/reports/odrl/CG-FINAL-profile-bp-20240808.html)
+- [W3C Market Data Profile](https://www.w3.org/2021/md-odrl-profile/v1/)
+- [EKGF DPROD](https://ekgf.github.io/dprod/)
+
+---
+
+**Version**: 0.7 | **Date**: 2026-02-16

--- a/adalbert-contracts/adalbert-core.ttl
+++ b/adalbert-contracts/adalbert-core.ttl
@@ -1,0 +1,306 @@
+# =============================================================================
+# Adalbert Core Ontology — ODRL 2.2 Profile Extension
+# Version: 0.7
+# Date: 2026-02-04
+# =============================================================================
+# Adalbert is a proper ODRL 2.2 profile. It uses ODRL terms wherever ODRL
+# defines them and only adds terms for genuinely new capabilities:
+#
+#   - Duty lifecycle (State + state property)
+#   - Deadline on duties
+#   - Recurrence on duties (RFC 5545 RRULE)
+#   - Duty party roles (subject, object)
+#   - Data contracts and subscriptions (domain subtypes)
+#   - Asset/party hierarchy (partOf, memberOf)
+#   - Structured operand resolution (resolutionPath)
+#   - Runtime references (RuntimeReference, currentAgent, currentDateTime)
+#   - Logical negation (not)
+#
+# Everything else — Rule types, Policy types, Constraint types, operators,
+# core properties — comes from ODRL 2.2 directly.
+# =============================================================================
+
+@prefix adalbert:    <https://vocabulary.bigbank/adalbert/> .
+@prefix rl2:     <https://vocabulary.bigbank/rl2/> .
+@prefix odrl:    <http://www.w3.org/ns/odrl/2/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+
+# =============================================================================
+# ONTOLOGY DECLARATION
+# =============================================================================
+
+<https://vocabulary.bigbank/adalbert/> a owl:Ontology ;
+    dcterms:title "Adalbert Core Ontology"@en ;
+    dcterms:description """
+        Adalbert: a proper ODRL 2.2 profile for deterministic data governance.
+
+        Uses ODRL terms for all standard constructs (Rule types, Policy types,
+        Constraint types, operators, core properties). Adds only:
+        - Explicit duty lifecycle (Pending -> Active -> Fulfilled/Violated)
+        - Deadline property on odrl:Duty
+        - Recurrence property on odrl:Duty (RFC 5545 RRULE)
+        - Duty party roles (subject = duty bearer, object = affected party)
+        - Data contract and subscription subtypes
+        - Asset/party hierarchy properties
+        - Structured operand resolution via resolutionPath
+        - Runtime references for dynamic right-operand values
+        - Logical negation (not) on LogicalConstraint
+
+        Adalbert policies are valid ODRL 2.2 policies. Any ODRL processor can
+        partially understand them; Adalbert-aware processors handle the
+        extensions.
+    """@en ;
+    dcterms:created "2026-02-02"^^xsd:date ;
+    dcterms:modified "2026-02-06"^^xsd:date ;
+    owl:versionInfo "0.7" ;
+    owl:versionIRI <https://vocabulary.bigbank/adalbert/0.7> ;
+    rdfs:seeAlso <https://vocabulary.bigbank/rl2/> ,
+                 <http://www.w3.org/ns/odrl/2/> .
+
+# =============================================================================
+# PROFILE CONSTRAINTS (documentation of ODRL usage)
+# =============================================================================
+# Adalbert fixes odrl:conflict to odrl:prohibit (declared at profile level in adalbert-prof.ttl).
+# Adalbert does not use: odrl:Ticket, odrl:Request, odrl:AssetCollection,
+# odrl:PartyCollection, odrl:remedy, odrl:consequence, odrl:xone.
+
+# =============================================================================
+# LIFECYCLE STATE (genuinely new)
+# =============================================================================
+
+adalbert:State a owl:Class ;
+    rdfs:label "State"@en ;
+    skos:definition "Unified lifecycle state for duties and contracts."@en ;
+    owl:oneOf (adalbert:Pending adalbert:Active adalbert:Fulfilled adalbert:Violated) ;
+    rdfs:comment """
+        Four states cover both duty and contract lifecycles.
+
+        On duties (evaluated during Eval):
+        - Pending: condition not yet satisfied
+        - Active: condition met, action required
+        - Fulfilled: action performed
+        - Violated: deadline passed without performance
+
+        On contracts/subscriptions (administrative, not evaluated at request time):
+        - Pending: not yet in force
+        - Active: in force
+        - Fulfilled: obligations complete
+        - Violated: breached
+
+        Unified by design: the same four transitions apply to both domains,
+        and a single state property avoids proliferating parallel enums.
+        The formal semantics (§4.1) tracks only duty state during evaluation;
+        contract state is managed by external administrative processes.
+    """@en .
+
+adalbert:Pending a adalbert:State ;
+    rdfs:label "Pending"@en ;
+    skos:definition "Condition not yet satisfied; not yet in force."@en .
+
+adalbert:Active a adalbert:State ;
+    rdfs:label "Active"@en ;
+    skos:definition "Condition satisfied, action required; in force."@en .
+
+adalbert:Fulfilled a adalbert:State ;
+    rdfs:label "Fulfilled"@en ;
+    skos:definition "Action performed; obligations complete."@en .
+
+adalbert:Violated a adalbert:State ;
+    rdfs:label "Violated"@en ;
+    skos:definition "Deadline passed without performance; breached."@en .
+
+adalbert:state a owl:ObjectProperty ;
+    rdfs:label "state"@en ;
+    skos:definition "Current lifecycle state."@en ;
+    rdfs:domain [ owl:unionOf (odrl:Duty adalbert:DataContract adalbert:Subscription) ] ;
+    rdfs:range adalbert:State .
+
+# =============================================================================
+# DEADLINE (genuinely new)
+# =============================================================================
+
+adalbert:deadline a owl:DatatypeProperty ;
+    rdfs:label "deadline"@en ;
+    skos:definition "Time constraint for duty fulfillment."@en ;
+    rdfs:domain odrl:Duty ;
+    rdfs:comment """
+        Supports multiple forms:
+        - xsd:dateTime: absolute deadline (e.g., 2026-12-31T23:59:59Z)
+        - xsd:duration: relative to activation (e.g., P30D, PT24H)
+
+        For duration: deadline = activationTime + duration.
+        No rdfs:range declared because the range is a union of datatypes;
+        SHACL enforces the allowed types.
+    """@en .
+
+# =============================================================================
+# RECURRENCE (genuinely new)
+# =============================================================================
+
+adalbert:recurrence a owl:DatatypeProperty ;
+    rdfs:label "recurrence"@en ;
+    skos:definition "RFC 5545 RRULE defining when duty instances are generated."@en ;
+    rdfs:domain odrl:Duty ;
+    rdfs:range xsd:string ;
+    rdfs:comment """
+        An RFC 5545 RRULE string (e.g., FREQ=DAILY;BYHOUR=6;BYMINUTE=0).
+        Defines the schedule on which duty instances are created.
+        Each instance follows the standard duty lifecycle independently.
+        The deadline property defines the per-instance fulfillment window.
+        Any iCal-compliant library can parse the value.
+    """@en .
+
+# =============================================================================
+# CONTRACT CLASSES (genuinely new — domain subtypes)
+# =============================================================================
+
+adalbert:DataContract a owl:Class ;
+    rdfs:label "Data Contract"@en ;
+    skos:definition "Policy offer defining data access terms."@en ;
+    rdfs:subClassOf odrl:Offer ;
+    rdfs:comment """
+        A DataContract is an Offer from a data provider.
+        It defines permissions, duties, and prohibitions for data access.
+
+        When accepted (subscribed), becomes a Subscription (Agreement).
+    """@en .
+
+adalbert:Subscription a owl:Class ;
+    rdfs:label "Subscription"@en ;
+    skos:definition "Activated data contract binding provider and consumer."@en ;
+    rdfs:subClassOf odrl:Agreement ;
+    owl:disjointWith adalbert:DataContract ;
+    rdfs:comment """
+        A Subscription is an activated DataContract.
+        - assigner: data provider (from contract)
+        - assignee: data consumer (subscriber)
+
+        Bilateral: both parties may have active duties.
+    """@en .
+
+# =============================================================================
+# CONTRACT PROPERTIES (genuinely new)
+# =============================================================================
+
+adalbert:subscribesTo a owl:ObjectProperty ;
+    rdfs:label "subscribes to"@en ;
+    skos:definition "The contract this subscription activates."@en ;
+    rdfs:domain adalbert:Subscription ;
+    rdfs:range adalbert:DataContract .
+
+adalbert:effectiveDate a owl:DatatypeProperty ;
+    rdfs:label "effective date"@en ;
+    skos:definition "When the contract/subscription becomes effective."@en ;
+    rdfs:domain [ owl:unionOf (adalbert:DataContract adalbert:Subscription) ] ;
+    rdfs:range xsd:dateTime .
+
+adalbert:expirationDate a owl:DatatypeProperty ;
+    rdfs:label "expiration date"@en ;
+    skos:definition "When the contract/subscription expires."@en ;
+    rdfs:domain [ owl:unionOf (adalbert:DataContract adalbert:Subscription) ] ;
+    rdfs:range xsd:dateTime .
+
+# =============================================================================
+# HIERARCHY EXTENSIONS (genuinely new)
+# =============================================================================
+
+adalbert:partOf a owl:ObjectProperty, owl:TransitiveProperty ;
+    rdfs:label "part of"@en ;
+    skos:definition "Asset contained in larger asset."@en ;
+    rdfs:subPropertyOf odrl:partOf ;
+    rdfs:domain odrl:Asset ;
+    rdfs:range odrl:Asset ;
+    rdfs:comment "Transitive asset hierarchy. Bridges to ODRL via rdfs:subPropertyOf odrl:partOf — ODRL processors with RDFS reasoning can interpret Adalbert hierarchies. Transitivity and typed domains are Adalbert additions not inherited by the base property."@en .
+
+adalbert:memberOf a owl:ObjectProperty, owl:TransitiveProperty ;
+    rdfs:label "member of"@en ;
+    skos:definition "Party member of group/organization."@en ;
+    rdfs:subPropertyOf odrl:partOf ;
+    rdfs:domain odrl:Party ;
+    rdfs:range odrl:Party ;
+    rdfs:comment "Transitive party hierarchy. Bridges to ODRL via rdfs:subPropertyOf odrl:partOf — ODRL processors with RDFS reasoning can interpret Adalbert hierarchies. Transitivity and typed domains are Adalbert additions not inherited by the base property."@en .
+
+# =============================================================================
+# DUTY PARTY ROLES (genuinely new)
+# =============================================================================
+
+adalbert:subject a owl:ObjectProperty ;
+    rdfs:label "subject"@en ;
+    skos:definition "Party bearing the duty (must perform the action)."@en ;
+    rdfs:subPropertyOf odrl:assignee ;
+    rdfs:domain odrl:Duty ;
+    rdfs:range odrl:Party ;
+    rdfs:comment "The duty bearer. Bridges to ODRL via rdfs:subPropertyOf odrl:assignee (itself a sub-property of odrl:function). Aligns with md:subject (W3C Market Data) and rl2:subject."@en .
+
+adalbert:object a owl:ObjectProperty ;
+    rdfs:label "object"@en ;
+    skos:definition "Party affected by the duty action."@en ;
+    rdfs:subPropertyOf odrl:function ;
+    rdfs:domain odrl:Duty ;
+    rdfs:range odrl:Party ;
+    rdfs:comment "The party affected by or receiving the result of the duty action (e.g., who is notified, who receives the report). Bridges to ODRL via rdfs:subPropertyOf odrl:function. Generic alternative to ODRL Common Vocabulary party functions (informedParty, compensatedParty, etc.) — use those when the specific semantics fits, use adalbert:object for consistency or when no specific function applies. Aligns with md:object (W3C Market Data) and rl2:counterparty."@en .
+
+# =============================================================================
+# OPERAND RESOLUTION (genuinely new)
+# =============================================================================
+
+adalbert:resolutionPath a owl:DatatypeProperty ;
+    rdfs:label "resolution path"@en ;
+    skos:definition "Dot-separated path from canonical root to value."@en ;
+    rdfs:domain odrl:LeftOperand ;
+    rdfs:range xsd:string ;
+    rdfs:comment """
+        Path must start with a canonical root: agent, asset, context.
+        Examples: agent.role, asset.classification, context.purpose.
+        Resolution: resolve(path, Env) -> Value
+    """@en .
+
+# =============================================================================
+# RUNTIME REFERENCES (genuinely new)
+# =============================================================================
+
+adalbert:RuntimeReference a owl:Class ;
+    rdfs:label "Runtime Reference"@en ;
+    skos:definition "Value resolved at evaluation time."@en .
+
+adalbert:currentAgent a adalbert:RuntimeReference, odrl:Party ;
+    rdfs:label "current agent"@en ;
+    skos:definition "The requesting agent."@en ;
+    rdfs:comment """
+        Reserved for constraint identity comparisons. Runtime resolution
+        in right-operand position requires RL2 (rl2:rightOperandRef).
+        Typed as both RuntimeReference and odrl:Party for ODRL processor
+        compatibility. For rules applying to any requesting agent, omit
+        odrl:assignee (standard ODRL); do not use currentAgent as assignee.
+    """@en .
+
+adalbert:currentDateTime a odrl:LeftOperand, adalbert:RuntimeReference ;
+    rdfs:label "current date time"@en ;
+    skos:definition "Evaluation timestamp."@en ;
+    rdfs:seeAlso odrl:dateTime ;
+    rdfs:comment "Equivalent to odrl:dateTime in constraint evaluation. Dual-typed as RuntimeReference to enable resolution at evaluation time."@en .
+
+# =============================================================================
+# LOGICAL NEGATION (genuinely new — ODRL lacks this)
+# =============================================================================
+
+adalbert:not a owl:ObjectProperty ;
+    rdfs:label "not"@en ;
+    skos:definition "Logical negation on a constraint."@en ;
+    rdfs:domain odrl:LogicalConstraint ;
+    rdfs:range [ owl:unionOf (odrl:Constraint odrl:LogicalConstraint) ] ;
+    rdfs:comment """
+        ODRL defines odrl:and and odrl:or on LogicalConstraint but lacks
+        negation. Adalbert adds adalbert:not following the same pattern:
+          _:lc a odrl:LogicalConstraint ;
+              adalbert:not _:c1 .
+    """@en .
+
+# =============================================================================
+# END OF ONTOLOGY
+# =============================================================================

--- a/adalbert-contracts/adalbert-due.ttl
+++ b/adalbert-contracts/adalbert-due.ttl
@@ -1,0 +1,597 @@
+# =============================================================================
+# Adalbert Data Use Profile (DUE)
+# Version: 0.7
+# Date: 2026-02-03
+# =============================================================================
+# Complete data governance vocabulary: operands, actions, concept values.
+#
+# All operands are typed as odrl:LeftOperand (not adalbert:LeftOperand).
+# Actions from ODRL Common Vocabulary are used directly (odrl:use, odrl:read,
+# odrl:display, odrl:distribute, odrl:delete, odrl:modify, odrl:aggregate,
+# odrl:anonymize, odrl:derive). DUE-only actions use the adalbert-due: prefix.
+# Action hierarchy uses odrl:includedIn.
+# Operand resolution uses adalbert:resolutionPath (Adalbert extension).
+# =============================================================================
+
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
+@prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdf:      <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:      <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms:  <http://purl.org/dc/terms/> .
+@prefix org:      <http://www.w3.org/ns/org#> .
+
+# =============================================================================
+# PROFILE DECLARATION
+# =============================================================================
+
+<https://vocabulary.bigbank/adalbert/due/> a owl:Ontology ;
+    dcterms:title "Adalbert Data Use Profile"@en ;
+    dcterms:description """
+        Complete data governance vocabulary for Adalbert.
+
+        Covers:
+        - Purpose and classification constraints
+        - Asset metadata (class, market, benchmark)
+        - Jurisdiction and residency requirements
+        - Retention and processing controls
+        - Audit and logging requirements
+        - Identity and access control (role, org, project)
+        - Environment and network constraints
+        - Data freshness (timeliness, delay)
+        - Usage modes (display, non-display, derive)
+        - Derivation constraints (commingled, non-substitutive)
+        - Consent and legal basis
+        - Obligation actions (reporting, delivery, notification)
+
+        Actions from ODRL Common Vocabulary are used directly (odrl:use,
+        odrl:read, odrl:display, etc.). DUE adds domain-specific actions
+        (nonDisplay, conformTo, log, notify, report, deliver, etc.).
+        All operands are odrl:LeftOperand with adalbert:resolutionPath.
+    """@en ;
+    dcterms:created "2026-02-03"^^xsd:date ;
+    owl:versionInfo "0.7" ;
+    owl:imports <https://vocabulary.bigbank/adalbert/> .
+
+# =============================================================================
+# CONCEPT SCHEME
+# =============================================================================
+
+adalbert-due:scheme a skos:ConceptScheme ;
+    rdfs:label "Adalbert DUE Vocabulary"@en ;
+    skos:definition "Concept scheme for the Adalbert Data Use vocabulary."@en .
+
+# =============================================================================
+# PURPOSE OPERANDS
+# =============================================================================
+
+odrl:purpose adalbert:resolutionPath "context.purpose" ;
+    rdfs:comment "Purpose values are skos:Concept instances. Add skos:broader links when a purpose hierarchy is needed."@en .
+
+# Purpose taxonomy
+adalbert-due:analytics a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "analytics"@en ;
+    skos:definition "General analytical use."@en .
+
+adalbert-due:research a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "research"@en ;
+    skos:definition "Research and development."@en .
+
+adalbert-due:compliance a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "compliance"@en ;
+    skos:definition "Regulatory compliance."@en .
+
+adalbert-due:operations a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "operations"@en ;
+    skos:definition "Operational use."@en .
+
+# =============================================================================
+# CLASSIFICATION OPERANDS
+# =============================================================================
+
+adalbert-due:classification a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "classification"@en ;
+    skos:definition "Data classification level."@en ;
+    adalbert:resolutionPath "asset.classification" .
+
+adalbert-due:sensitivity a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "sensitivity"@en ;
+    skos:definition "Data sensitivity type."@en ;
+    adalbert:resolutionPath "asset.sensitivity" .
+
+# Classification values
+adalbert-due:public a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "public"@en .
+adalbert-due:internal a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "internal"@en .
+adalbert-due:confidential a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "confidential"@en .
+adalbert-due:restricted a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "restricted"@en .
+
+# Sensitivity values
+adalbert-due:pii a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "PII"@en ;
+    skos:definition "Personally Identifiable Information."@en .
+adalbert-due:mnpi a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "MNPI"@en ;
+    skos:definition "Material Non-Public Information."@en .
+adalbert-due:phi a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "PHI"@en ;
+    skos:definition "Protected Health Information."@en .
+
+# =============================================================================
+# ASSET METADATA OPERANDS
+# =============================================================================
+
+adalbert-due:assetClass a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "asset class"@en ;
+    skos:definition "Financial instrument or data classification."@en ;
+    adalbert:resolutionPath "asset.class" ;
+    rdfs:comment "E.g., equity, fixed-income, fx, commodity, reference."@en .
+
+adalbert-due:market a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "market"@en ;
+    skos:definition "Trading venue or market of origin."@en ;
+    adalbert:resolutionPath "asset.market" ;
+    rdfs:comment "E.g., NYSE, LSE, CME, OTC."@en .
+
+adalbert-due:isBenchmark a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "is benchmark"@en ;
+    skos:definition "Whether asset is a benchmark or index."@en ;
+    adalbert:resolutionPath "asset.isBenchmark" ;
+    rdfs:comment "Benchmarks often have stricter usage constraints."@en .
+
+# =============================================================================
+# JURISDICTION OPERANDS
+# =============================================================================
+
+adalbert-due:jurisdiction a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "jurisdiction"@en ;
+    skos:definition "Legal jurisdiction governing data use."@en ;
+    adalbert:resolutionPath "context.jurisdiction" .
+
+adalbert-due:residency a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "residency"@en ;
+    skos:definition "Data residency location."@en ;
+    adalbert:resolutionPath "asset.residency" .
+
+# =============================================================================
+# TEMPORAL OPERANDS
+# =============================================================================
+
+adalbert-due:retentionPeriod a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "retention period"@en ;
+    skos:definition "Maximum time data may be retained."@en ;
+    adalbert:resolutionPath "asset.retentionPeriod" .
+
+adalbert-due:expiry a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "expiry"@en ;
+    skos:definition "Expiration date of the policy."@en ;
+    adalbert:resolutionPath "asset.expiry" .
+
+# =============================================================================
+# PROCESSING OPERANDS
+# =============================================================================
+
+adalbert-due:processingMode a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "processing mode"@en ;
+    skos:definition "How data is processed."@en ;
+    adalbert:resolutionPath "context.processingMode" .
+
+adalbert-due:human a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "human"@en .
+adalbert-due:automated a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "automated"@en .
+adalbert-due:modelTraining a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "model training"@en .
+adalbert-due:inference a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "inference"@en .
+
+# =============================================================================
+# AUDIT OPERANDS
+# =============================================================================
+
+adalbert-due:auditRequired a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "audit required"@en ;
+    skos:definition "Whether audit logging is required."@en ;
+    adalbert:resolutionPath "asset.auditRequired" .
+
+# =============================================================================
+# IDENTITY OPERANDS
+# =============================================================================
+
+adalbert-due:role a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "role"@en ;
+    skos:definition "Role of the requesting agent."@en ;
+    adalbert:resolutionPath "agent.role" .
+
+adalbert-due:organization a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "organization"@en ;
+    skos:definition "Organization of the requesting agent."@en ;
+    adalbert:resolutionPath "agent.organization" ;
+    rdfs:comment "Hierarchy via org:subOrganizationOf."@en .
+
+adalbert-due:costCenter a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "cost center"@en ;
+    skos:definition "Cost center of the requesting agent."@en ;
+    adalbert:resolutionPath "agent.costCenter" .
+
+adalbert-due:project a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "project"@en ;
+    skos:definition "Project context of the request."@en ;
+    adalbert:resolutionPath "context.project" .
+
+adalbert-due:recipientType a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "recipient type"@en ;
+    skos:definition "Type of data recipient."@en ;
+    adalbert:resolutionPath "agent.recipientType" ;
+    rdfs:comment "E.g., internal, external, professional, retail."@en .
+
+# Recipient type values
+adalbert-due:internalRecipient a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "internal recipient"@en ;
+    skos:definition "Recipient within the same organization."@en .
+adalbert-due:externalRecipient a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "external recipient"@en ;
+    skos:definition "Recipient outside the organization."@en .
+adalbert-due:professional a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "professional"@en ;
+    skos:definition "Licensed professional user."@en .
+adalbert-due:retail a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "retail"@en ;
+    skos:definition "Retail/individual user."@en .
+
+# =============================================================================
+# ENVIRONMENT OPERANDS
+# =============================================================================
+
+adalbert-due:environment a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "environment"@en ;
+    skos:definition "Execution environment."@en ;
+    adalbert:resolutionPath "context.environment" .
+
+adalbert-due:production a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "production"@en .
+adalbert-due:staging a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "staging"@en .
+adalbert-due:development a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "development"@en .
+adalbert-due:sandbox a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "sandbox"@en .
+
+adalbert-due:network a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "network"@en ;
+    skos:definition "Network zone of the request."@en ;
+    adalbert:resolutionPath "context.network" .
+
+adalbert-due:internalNetwork a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "internal network"@en .
+adalbert-due:externalNetwork a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "external network"@en .
+adalbert-due:cloudNetwork a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "cloud network"@en .
+
+# =============================================================================
+# SERVICE LEVEL OPERANDS
+# =============================================================================
+
+adalbert-due:availability a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "availability"@en ;
+    skos:definition "Service availability percentage."@en ;
+    adalbert:resolutionPath "context.availability" ;
+    rdfs:comment "Typically measured as uptime percentage over a period (e.g., 99.9%)."@en .
+
+adalbert-due:latency a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "latency"@en ;
+    skos:definition "Response latency at a given percentile."@en ;
+    adalbert:resolutionPath "context.latency" ;
+    rdfs:comment "Measured as duration (e.g., P99 latency <= PT0.2S)."@en .
+
+adalbert-due:throughput a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "throughput"@en ;
+    skos:definition "Request throughput capacity."@en ;
+    adalbert:resolutionPath "context.throughput" ;
+    rdfs:comment "Measured in requests per second."@en .
+
+# =============================================================================
+# DATA QUALITY OPERANDS
+# =============================================================================
+
+adalbert-due:completeness a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "completeness"@en ;
+    skos:definition "Data completeness percentage."@en ;
+    adalbert:resolutionPath "asset.completeness" ;
+    rdfs:comment "Percentage of non-null required fields."@en .
+
+adalbert-due:accuracy a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "accuracy"@en ;
+    skos:definition "Data accuracy percentage."@en ;
+    adalbert:resolutionPath "asset.accuracy" ;
+    rdfs:comment "Percentage of records passing validation rules."@en .
+
+# =============================================================================
+# TIMELINESS OPERANDS
+# =============================================================================
+
+adalbert-due:timeliness a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "timeliness"@en ;
+    skos:definition "Required data freshness category."@en ;
+    adalbert:resolutionPath "asset.timeliness" .
+
+adalbert-due:delayMinutes a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "delay minutes"@en ;
+    skos:definition "Maximum acceptable delay in minutes."@en ;
+    adalbert:resolutionPath "asset.delayMinutes" .
+
+# Timeliness values
+adalbert-due:realtime a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "real-time"@en ;
+    skos:definition "Data with minimal latency (sub-second)."@en .
+adalbert-due:nearRealtime a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "near real-time"@en ;
+    skos:definition "Data with short delay (seconds to minutes)."@en .
+adalbert-due:delayed a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "delayed"@en ;
+    skos:definition "Data with significant delay (15+ minutes)."@en .
+adalbert-due:endOfDay a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "end of day"@en ;
+    skos:definition "Data available after market close."@en .
+adalbert-due:historical a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "historical"@en ;
+    skos:definition "Historical/archived data."@en .
+
+# =============================================================================
+# CONSENT AND LEGAL BASIS
+# =============================================================================
+
+adalbert-due:legalBasis a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "legal basis"@en ;
+    skos:definition "Legal basis for processing."@en ;
+    adalbert:resolutionPath "context.legalBasis" .
+
+adalbert-due:consent a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "consent"@en .
+adalbert-due:contract a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "contract"@en .
+adalbert-due:legalObligation a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "legal obligation"@en .
+adalbert-due:vitalInterest a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "vital interest"@en .
+adalbert-due:publicTask a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "public task"@en .
+adalbert-due:legitimateInterest a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "legitimate interest"@en .
+
+adalbert-due:consentId a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "consent ID"@en ;
+    skos:definition "Reference to consent record."@en ;
+    adalbert:resolutionPath "context.consentId" .
+
+# =============================================================================
+# ACCESS PATTERN OPERANDS
+# =============================================================================
+
+adalbert-due:accessPattern a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "access pattern"@en ;
+    skos:definition "Type of data access."@en ;
+    adalbert:resolutionPath "context.accessPattern" .
+
+adalbert-due:batch a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "batch"@en .
+adalbert-due:streaming a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "streaming"@en .
+adalbert-due:interactive a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "interactive"@en .
+adalbert-due:api a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "API"@en .
+
+adalbert-due:volumeLimit a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "volume limit"@en ;
+    skos:definition "Maximum data volume per request."@en ;
+    adalbert:resolutionPath "context.volumeLimit" .
+
+adalbert-due:rateLimit a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "rate limit"@en ;
+    skos:definition "Maximum requests per time period."@en ;
+    adalbert:resolutionPath "context.rateLimit" .
+
+# =============================================================================
+# CHANNEL OPERANDS
+# =============================================================================
+
+adalbert-due:channel a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "channel"@en ;
+    skos:definition "Communication or delivery channel."@en ;
+    adalbert:resolutionPath "context.channel" ;
+    rdfs:comment "E.g., email, chat, phone, api, sftp."@en .
+
+adalbert-due:serviceWindow a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "service window"@en ;
+    skos:definition "Time window during which a service is available."@en ;
+    adalbert:resolutionPath "context.serviceWindow" ;
+    rdfs:comment "E.g., business-hours, 24x7, weekdays."@en .
+
+# =============================================================================
+# SUBSCRIPTION OPERANDS
+# =============================================================================
+
+adalbert-due:subscriptionTier a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "subscription tier"@en ;
+    skos:definition "Access tier or subscription level."@en ;
+    adalbert:resolutionPath "context.subscriptionTier" ;
+    rdfs:comment "E.g., free, basic, premium, enterprise."@en .
+
+# =============================================================================
+# DERIVATION OPERANDS
+# =============================================================================
+
+adalbert-due:derivationType a odrl:LeftOperand, skos:Concept ;
+    rdfs:label "derivation type"@en ;
+    skos:definition "Type of derivation being performed."@en ;
+    adalbert:resolutionPath "context.derivationType" .
+
+adalbert-due:commingled a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "commingled"@en ;
+    skos:definition "Derived data mixed with other sources."@en .
+adalbert-due:nonSubstitutive a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "non-substitutive"@en ;
+    skos:definition "Derived data cannot substitute for original."@en .
+adalbert-due:newProduct a skos:Concept ;
+    skos:inScheme adalbert-due:scheme ;
+    rdfs:label "new product"@en ;
+    skos:definition "Substantially transformed into new product."@en .
+
+# =============================================================================
+# ODRL COMMON VOCABULARY ACTIONS (used directly)
+# =============================================================================
+# These actions come from ODRL 2.2 Common Vocabulary. DUE uses them directly
+# rather than redefining them. ODRL already defines their includedIn hierarchy.
+#
+# odrl:use        — General use (top of hierarchy)
+# odrl:read       — Read/view (includedIn odrl:use)
+# odrl:display    — Display to human users (includedIn odrl:use)
+# odrl:distribute — Distribute to third parties (includedIn odrl:use)
+# odrl:delete     — Delete the asset (includedIn odrl:use)
+# odrl:modify     — Modify the asset (includedIn odrl:use)
+# odrl:aggregate  — Aggregate with other data (includedIn odrl:use)
+# odrl:anonymize  — Remove identifying information (includedIn odrl:use)
+# odrl:derive     — Create derived data (includedIn odrl:use)
+
+# =============================================================================
+# DUE-SPECIFIC ACTIONS (no ODRL equivalent)
+# =============================================================================
+
+adalbert-due:nonDisplay a odrl:Action, skos:Concept ;
+    rdfs:label "non-display"@en ;
+    skos:definition "Use data for automated/programmatic purposes."@en ;
+    odrl:includedIn odrl:use ;
+    rdfs:comment "Algorithmic use: models, automation, calculations."@en .
+
+adalbert-due:conformTo a odrl:Action, skos:Concept ;
+    rdfs:label "conform to"@en ;
+    skos:definition "Conform to a schema or specification."@en ;
+    rdfs:seeAlso dcterms:conformsTo ;
+    rdfs:comment """Provider governance duty: ensure data conforms to published schema.
+        The duty target (odrl:target) is the schema/specification — the same resource
+        that dct:conformsTo would point to as a static metadata assertion. conformTo
+        is the operational counterpart: an ongoing obligation to maintain conformance.
+        No odrl:includedIn — conformTo is a duty-only action (schema/quality SLA).
+        The includedIn hierarchy governs permission subsumption (granting odrl:use
+        implicitly grants sub-actions). conformTo never appears in permissions, so
+        chaining it to odrl:use would create a false subsumption."""@en .
+
+adalbert-due:log a odrl:Action, skos:Concept ;
+    rdfs:label "log"@en ;
+    skos:definition "Log access to the asset."@en ;
+    odrl:includedIn odrl:inform .
+
+adalbert-due:notify a odrl:Action, skos:Concept ;
+    rdfs:label "notify"@en ;
+    skos:definition "Notify relevant parties."@en ;
+    odrl:includedIn odrl:inform .
+
+adalbert-due:report a odrl:Action, skos:Concept ;
+    rdfs:label "report"@en ;
+    skos:definition "Submit usage reports."@en ;
+    odrl:includedIn odrl:inform ;
+    rdfs:comment "Typically an assignee duty: report usage to data owner."@en .
+
+adalbert-due:deliver a odrl:Action, skos:Concept ;
+    rdfs:label "deliver"@en ;
+    skos:definition "Deliver data to consumer."@en ;
+    odrl:includedIn odrl:distribute ;
+    rdfs:comment "Typically an assigner duty in data contracts."@en .
+
+# =============================================================================
+# SPECIALIZED ACTIONS
+# =============================================================================
+
+adalbert-due:calculateIndex a odrl:Action, skos:Concept ;
+    rdfs:label "calculate index"@en ;
+    skos:definition "Use data for index/benchmark calculation."@en ;
+    odrl:includedIn odrl:derive .
+
+adalbert-due:algorithmicTrading a odrl:Action, skos:Concept ;
+    rdfs:label "algorithmic trading"@en ;
+    skos:definition "Use data for automated trading decisions."@en ;
+    odrl:includedIn adalbert-due:nonDisplay .
+
+# =============================================================================
+# DATA MANIPULATION ACTIONS
+# =============================================================================
+
+adalbert-due:query a odrl:Action, skos:Concept ;
+    rdfs:label "query"@en ;
+    skos:definition "Query/select data."@en ;
+    odrl:includedIn odrl:read .
+
+adalbert-due:export a odrl:Action, skos:Concept ;
+    rdfs:label "export"@en ;
+    skos:definition "Export data outside the system."@en ;
+    odrl:includedIn odrl:distribute .
+
+adalbert-due:copy a odrl:Action, skos:Concept ;
+    rdfs:label "copy"@en ;
+    skos:definition "Copy data to another location."@en ;
+    odrl:includedIn odrl:reproduce .
+
+adalbert-due:link a odrl:Action, skos:Concept ;
+    rdfs:label "link"@en ;
+    skos:definition "Link/join with other datasets."@en ;
+    odrl:includedIn odrl:aggregate .
+
+adalbert-due:profile a odrl:Action, skos:Concept ;
+    rdfs:label "profile"@en ;
+    skos:definition "Create profiles from data."@en ;
+    odrl:includedIn odrl:derive .
+
+# =============================================================================
+# END OF PROFILE
+# =============================================================================

--- a/adalbert-contracts/adalbert-prof.ttl
+++ b/adalbert-contracts/adalbert-prof.ttl
@@ -1,0 +1,88 @@
+# =============================================================================
+# Adalbert Profile Declaration (DXPROF)
+# Version: 0.7
+# Date: 2026-02-04
+# =============================================================================
+# W3C Profiles Vocabulary metadata for Adalbert.
+# Adalbert is a proper ODRL 2.2 profile — it uses ODRL terms and adds
+# only genuinely new extensions.
+# =============================================================================
+
+@prefix adalbert:    <https://vocabulary.bigbank/adalbert/> .
+@prefix prof:    <http://www.w3.org/ns/dx/prof/> .
+@prefix role:    <http://www.w3.org/ns/dx/prof/role/> .
+@prefix dct:     <http://purl.org/dc/terms/> .
+@prefix odrl:    <http://www.w3.org/ns/odrl/2/> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+# =============================================================================
+# BASE SPECIFICATION
+# =============================================================================
+
+odrl:core a dct:Standard ;
+    dct:title "ODRL Information Model 2.2"@en ;
+    dct:identifier <http://www.w3.org/TR/odrl-model/> .
+
+# =============================================================================
+# Adalbert CORE PROFILE
+# =============================================================================
+
+<https://vocabulary.bigbank/adalbert/> a prof:Profile ;
+    dct:title "Adalbert Core"@en ;
+    dct:description """
+        Proper ODRL 2.2 profile for deterministic data governance.
+        Uses ODRL terms for standard constructs; adds lifecycle state,
+        deadline, recurrence, data contracts, hierarchy extensions,
+        operand resolution, runtime references, and logical negation.
+    """@en ;
+    prof:isProfileOf odrl:core ;
+    prof:hasToken "adalbert"^^xsd:token ;
+    odrl:conflict odrl:prohibit ;
+
+    prof:hasResource [
+        a prof:ResourceDescriptor ;
+        dct:title "Adalbert Specification"@en ;
+        prof:hasRole role:specification ;
+        prof:hasArtifact <https://vocabulary.bigbank/adalbert/docs/README.md>
+    ] , [
+        a prof:ResourceDescriptor ;
+        dct:title "Adalbert Formal Semantics"@en ;
+        prof:hasRole role:specification ;
+        prof:hasArtifact <https://vocabulary.bigbank/adalbert/docs/Adalbert_Semantics.md>
+    ] , [
+        a prof:ResourceDescriptor ;
+        dct:title "Adalbert Core Ontology"@en ;
+        prof:hasRole role:vocabulary ;
+        dct:conformsTo <http://www.w3.org/TR/owl2-overview/> ;
+        prof:hasArtifact <https://vocabulary.bigbank/adalbert/ontology/adalbert-core.ttl>
+    ] , [
+        a prof:ResourceDescriptor ;
+        dct:title "Adalbert SHACL Shapes"@en ;
+        prof:hasRole role:validation ;
+        dct:conformsTo <http://www.w3.org/ns/shacl#> ;
+        prof:hasArtifact <https://vocabulary.bigbank/adalbert/ontology/adalbert-shacl.ttl>
+    ] .
+
+# =============================================================================
+# DATA USE PROFILE
+# =============================================================================
+
+<https://vocabulary.bigbank/adalbert/due/> a prof:Profile ;
+    dct:title "Adalbert Data Use (DUE)"@en ;
+    dct:description "Complete data governance vocabulary: operands, actions, concept values."@en ;
+    prof:isProfileOf <https://vocabulary.bigbank/adalbert/> ;
+    prof:isTransitiveProfileOf odrl:core ;
+    prof:hasToken "adalbert-due"^^xsd:token ;
+
+    prof:hasResource [
+        a prof:ResourceDescriptor ;
+        dct:title "Adalbert DUE Vocabulary"@en ;
+        prof:hasRole role:vocabulary ;
+        dct:conformsTo <http://www.w3.org/TR/owl2-overview/> ;
+        prof:hasArtifact <https://vocabulary.bigbank/adalbert/profiles/adalbert-due.ttl>
+    ] .
+
+# =============================================================================
+# END
+# =============================================================================

--- a/adalbert-contracts/adalbert-shacl.ttl
+++ b/adalbert-contracts/adalbert-shacl.ttl
@@ -1,0 +1,552 @@
+# =============================================================================
+# Adalbert SHACL Shapes
+# Version: 0.7
+# Date: 2026-02-04
+# =============================================================================
+# Validation shapes for Adalbert policies.
+# All shapes target ODRL classes and use ODRL properties.
+# Adalbert-specific extensions are validated where they appear on ODRL types.
+# =============================================================================
+
+@prefix adalbert:    <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix adalbertsh:  <https://vocabulary.bigbank/adalbert/shapes/> .
+@prefix odrl:    <http://www.w3.org/ns/odrl/2/> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+# =============================================================================
+# REUSABLE PROPERTY GROUPS
+# =============================================================================
+
+adalbertsh:StatePropertyGroup
+    sh:path adalbert:state ;
+    sh:maxCount 1 ;
+    sh:in (adalbert:Pending adalbert:Active adalbert:Fulfilled adalbert:Violated) ;
+    sh:message "State must be Pending, Active, Fulfilled, or Violated." .
+
+adalbertsh:ProfilePropertyGroup
+    sh:path odrl:profile ;
+    sh:minCount 1 ;
+    sh:hasValue <https://vocabulary.bigbank/adalbert/> ;
+    sh:message "Adalbert policies must declare odrl:profile <https://vocabulary.bigbank/adalbert/>." .
+
+adalbertsh:NonEmptyClausesConstraint a sh:NodeShape ;
+    sh:or (
+        [ sh:property [ sh:path odrl:permission ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path odrl:prohibition ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path odrl:obligation ; sh:minCount 1 ] ]
+    ) ;
+    sh:message "Policy must have at least one permission, prohibition, or obligation." .
+
+# =============================================================================
+# POLICY SHAPE — profile and conflict declaration
+# =============================================================================
+
+adalbertsh:PolicyShape a sh:NodeShape ;
+    sh:targetClass odrl:Policy ;
+    sh:name "Policy Shape" ;
+
+    sh:property [
+        sh:path odrl:profile ;
+        sh:minCount 1 ;
+        sh:hasValue <https://vocabulary.bigbank/adalbert/> ;
+        sh:message "Adalbert policies must declare odrl:profile <https://vocabulary.bigbank/adalbert/>."
+    ] .
+
+# =============================================================================
+# SET SHAPE
+# =============================================================================
+
+adalbertsh:SetShape a sh:NodeShape ;
+    sh:targetClass odrl:Set ;
+    sh:name "Set Shape" ;
+
+    sh:property adalbertsh:ProfilePropertyGroup ;
+
+    sh:node adalbertsh:NonEmptyClausesConstraint ;
+
+    # odrl:target is optional on Sets (formal semantics: Asset?).
+    # When present, inherited by rules that omit their own target.
+    sh:property [
+        sh:path odrl:target ;
+        sh:message "Set policy may declare a policy-level target (inherited by rules)."
+    ] .
+
+# =============================================================================
+# OFFER SHAPE
+# =============================================================================
+
+adalbertsh:OfferShape a sh:NodeShape ;
+    sh:targetClass odrl:Offer ;
+    sh:name "Offer Shape" ;
+
+    sh:property adalbertsh:ProfilePropertyGroup ;
+
+    sh:node adalbertsh:NonEmptyClausesConstraint ;
+
+    # Offer requires assigner
+    sh:property [
+        sh:path odrl:assigner ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Offer must have exactly one assigner."
+    ] .
+
+# =============================================================================
+# AGREEMENT SHAPE
+# =============================================================================
+
+adalbertsh:AgreementShape a sh:NodeShape ;
+    sh:targetClass odrl:Agreement ;
+    sh:name "Agreement Shape" ;
+
+    sh:property adalbertsh:ProfilePropertyGroup ;
+
+    sh:node adalbertsh:NonEmptyClausesConstraint ;
+
+    sh:property [
+        sh:path odrl:assigner ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Agreement must have exactly one assigner."
+    ] ;
+
+    sh:property [
+        sh:path odrl:assignee ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Agreement must have exactly one assignee."
+    ] .
+
+# =============================================================================
+# PERMISSION SHAPE
+# =============================================================================
+
+adalbertsh:PermissionShape a sh:NodeShape ;
+    sh:targetClass odrl:Permission ;
+    sh:name "Permission Shape" ;
+
+    sh:property [
+        sh:path odrl:action ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Permission must have exactly one action."
+    ] ;
+
+    sh:property [
+        sh:path odrl:target ;
+        sh:maxCount 1 ;
+        sh:message "Permission may have at most one target (inherits from policy if absent)."
+    ] .
+
+# =============================================================================
+# PROHIBITION SHAPE
+# =============================================================================
+
+adalbertsh:ProhibitionShape a sh:NodeShape ;
+    sh:targetClass odrl:Prohibition ;
+    sh:name "Prohibition Shape" ;
+
+    sh:property [
+        sh:path odrl:action ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Prohibition must have exactly one action."
+    ] ;
+
+    sh:property [
+        sh:path odrl:target ;
+        sh:maxCount 1 ;
+        sh:message "Prohibition may have at most one target (inherits from policy if absent)."
+    ] .
+
+# =============================================================================
+# DUTY SHAPE
+# =============================================================================
+
+adalbertsh:DutyShape a sh:NodeShape ;
+    sh:targetClass odrl:Duty ;
+    sh:name "Duty Shape" ;
+
+    sh:property [
+        sh:path odrl:action ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Duty must have exactly one action."
+    ] ;
+
+    sh:property [
+        sh:path adalbert:deadline ;
+        sh:maxCount 1 ;
+        sh:or (
+            [ sh:datatype xsd:dateTime ]
+            [ sh:datatype xsd:duration ]
+        ) ;
+        sh:message "Deadline must be xsd:dateTime or xsd:duration."
+    ] ;
+
+    sh:property [
+        sh:path adalbert:recurrence ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:pattern "^FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)" ;
+        sh:message "Recurrence must be a valid RFC 5545 RRULE starting with FREQ=."
+    ] ;
+
+    sh:property [
+        sh:path adalbert:subject ;
+        sh:maxCount 1 ;
+        sh:class odrl:Party ;
+        sh:message "Duty subject must be a single odrl:Party."
+    ] ;
+
+    sh:property [
+        sh:path adalbert:object ;
+        sh:maxCount 1 ;
+        sh:class odrl:Party ;
+        sh:message "Duty object must be a single odrl:Party."
+    ] ;
+
+    sh:property adalbertsh:StatePropertyGroup .
+
+# =============================================================================
+# CONSTRAINT SHAPE
+# =============================================================================
+
+adalbertsh:ConstraintShape a sh:NodeShape ;
+    sh:targetClass odrl:Constraint ;
+    sh:name "Constraint Shape" ;
+
+    sh:property [
+        sh:path odrl:leftOperand ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Constraint must have exactly one leftOperand."
+    ] ;
+
+    sh:property [
+        sh:path odrl:operator ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Constraint must have exactly one operator."
+    ] ;
+
+    sh:property [
+        sh:path odrl:rightOperand ;
+        sh:minCount 1 ;
+        sh:message "Constraint must have a rightOperand."
+    ] .
+
+# =============================================================================
+# LOGICAL CONSTRAINT SHAPE
+# =============================================================================
+
+adalbertsh:LogicalConstraintShape a sh:NodeShape ;
+    sh:targetClass odrl:LogicalConstraint ;
+    sh:name "Logical Constraint Shape" ;
+
+    # Must have exactly one of: odrl:and, odrl:or, adalbert:not
+    sh:xone (
+        [ sh:property [ sh:path odrl:and ; sh:minCount 1 ; sh:maxCount 1 ] ]
+        [ sh:property [ sh:path odrl:or ; sh:minCount 1 ; sh:maxCount 1 ] ]
+        [ sh:property [ sh:path adalbert:not ; sh:minCount 1 ; sh:maxCount 1 ] ]
+    ) ;
+    sh:message "LogicalConstraint must have exactly one of: odrl:and, odrl:or, or adalbert:not." .
+
+# =============================================================================
+# DATA CONTRACT SHAPE
+# =============================================================================
+
+adalbertsh:DataContractShape a sh:NodeShape ;
+    sh:targetClass adalbert:DataContract ;
+    sh:name "Data Contract Shape" ;
+
+    sh:property adalbertsh:ProfilePropertyGroup ;
+
+    sh:node adalbertsh:NonEmptyClausesConstraint ;
+
+    sh:property [
+        sh:path odrl:assigner ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "DataContract must have exactly one assigner."
+    ] ;
+
+    sh:property adalbertsh:StatePropertyGroup ;
+
+    sh:property [
+        sh:path adalbert:effectiveDate ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime
+    ] ;
+
+    sh:property [
+        sh:path adalbert:expirationDate ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime
+    ] .
+
+# =============================================================================
+# SUBSCRIPTION SHAPE
+# =============================================================================
+
+adalbertsh:SubscriptionShape a sh:NodeShape ;
+    sh:targetClass adalbert:Subscription ;
+    sh:name "Subscription Shape" ;
+
+    sh:property adalbertsh:ProfilePropertyGroup ;
+
+    sh:node adalbertsh:NonEmptyClausesConstraint ;
+
+    # Explicit party constraints — Subscription is subClassOf Agreement,
+    # but without RDFS entailment AgreementShape won't target Subscription
+    # instances. Duplicate the party requirements here.
+    sh:property [
+        sh:path odrl:assigner ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Subscription must have exactly one assigner (data provider)."
+    ] ;
+
+    sh:property [
+        sh:path odrl:assignee ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "Subscription must have exactly one assignee (data consumer)."
+    ] ;
+
+    sh:property [
+        sh:path adalbert:subscribesTo ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class adalbert:DataContract ;
+        sh:message "Subscription must reference exactly one DataContract."
+    ] ;
+
+    sh:property adalbertsh:StatePropertyGroup ;
+
+    sh:property [
+        sh:path adalbert:effectiveDate ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime
+    ] ;
+
+    sh:property [
+        sh:path adalbert:expirationDate ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:dateTime
+    ] .
+
+# =============================================================================
+# LEFT OPERAND SHAPE
+# =============================================================================
+# sh:minCount 0: resolutionPath is optional in the shape because ODRL's
+# built-in left operands (odrl:dateTime, etc.) don't have it. Adalbert
+# profile operands MUST provide it — enforced by convention and DUE.
+#
+# The sh:pattern validates the root prefix only. Full path grammar enforcement
+# (identifier syntax, depth constraints, traversal rejection) is a runtime
+# concern per Adalbert_Semantics.md §6.2, not expressible in SHACL.
+
+adalbertsh:LeftOperandShape a sh:NodeShape ;
+    sh:targetClass odrl:LeftOperand ;
+    sh:name "Left Operand Shape" ;
+
+    sh:property [
+        sh:path adalbert:resolutionPath ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:pattern "^(agent|asset|context)\\." ;
+        sh:message "resolutionPath must start with agent., asset., or context."
+    ] .
+
+# =============================================================================
+# DUE OPERAND SHAPE — enforce resolutionPath on all DUE operands
+# =============================================================================
+# Unlike generic LeftOperandShape (which allows absent resolutionPath for ODRL
+# built-in operands like odrl:dateTime), DUE operands MUST declare a path.
+#
+# Validation model: this shape validates the DUE vocabulary itself, not
+# individual policies. The sh:targetNode list references operand IRIs
+# defined in adalbert-due.ttl. To validate, load both the DUE vocabulary
+# and this shapes graph:
+#   shacl validate --shapes adalbert-shacl.ttl --data adalbert-due.ttl
+# Policy-level validation (constraint structure, cardinality) is handled
+# by ConstraintShape and LeftOperandShape above.
+
+adalbertsh:DUEOperandShape a sh:NodeShape ;
+    sh:name "DUE Operand Shape" ;
+    sh:description "DUE operands must declare a resolution path." ;
+    sh:targetNode
+        odrl:purpose ,
+        adalbert-due:classification ,
+        adalbert-due:sensitivity ,
+        adalbert-due:assetClass ,
+        adalbert-due:market ,
+        adalbert-due:isBenchmark ,
+        adalbert-due:jurisdiction ,
+        adalbert-due:residency ,
+        adalbert-due:retentionPeriod ,
+        adalbert-due:expiry ,
+        adalbert-due:processingMode ,
+        adalbert-due:auditRequired ,
+        adalbert-due:role ,
+        adalbert-due:organization ,
+        adalbert-due:costCenter ,
+        adalbert-due:project ,
+        adalbert-due:recipientType ,
+        adalbert-due:environment ,
+        adalbert-due:network ,
+        adalbert-due:timeliness ,
+        adalbert-due:delayMinutes ,
+        adalbert-due:legalBasis ,
+        adalbert-due:consentId ,
+        adalbert-due:accessPattern ,
+        adalbert-due:volumeLimit ,
+        adalbert-due:rateLimit ,
+        adalbert-due:derivationType ;
+
+    sh:property [
+        sh:path adalbert:resolutionPath ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:pattern "^(agent|asset|context)\\." ;
+        sh:message "DUE operands must have exactly one resolutionPath starting with agent., asset., or context."
+    ] .
+
+# =============================================================================
+# PROFILE SHAPE — reject RL2-only and unsupported ODRL constructs
+# =============================================================================
+# Each shape targets nodes that use a rejected feature and declares a
+# constraint that always fails: sh:maxCount 0 on the targeted property
+# (for property-based rejections) or on rdf:type (for class-based
+# rejections, since any typed node has rdf:type >= 1).
+
+adalbertsh:RejectXoneShape a sh:NodeShape ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+            SELECT ?this WHERE {
+                ?this odrl:xone ?list .
+            }
+        """
+    ] ;
+    sh:property [
+        sh:path odrl:xone ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support xone operator."
+    ] .
+
+adalbertsh:RejectRemedyShape a sh:NodeShape ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+            SELECT ?this WHERE {
+                ?this odrl:remedy ?r .
+            }
+        """
+    ] ;
+    sh:property [
+        sh:path odrl:remedy ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:remedy. Deferred to RL2."
+    ] .
+
+adalbertsh:RejectConsequenceShape a sh:NodeShape ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+            SELECT ?this WHERE {
+                ?this odrl:consequence ?c .
+            }
+        """
+    ] ;
+    sh:property [
+        sh:path odrl:consequence ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:consequence. Deferred to RL2."
+    ] .
+
+adalbertsh:RejectTicketShape a sh:NodeShape ;
+    sh:targetClass odrl:Ticket ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:Ticket."
+    ] .
+
+adalbertsh:RejectRequestShape a sh:NodeShape ;
+    sh:targetClass odrl:Request ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:Request."
+    ] .
+
+adalbertsh:RejectAssetCollectionShape a sh:NodeShape ;
+    sh:targetClass odrl:AssetCollection ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:AssetCollection. Use adalbert:partOf hierarchy instead."
+    ] .
+
+adalbertsh:RejectPartyCollectionShape a sh:NodeShape ;
+    sh:targetClass odrl:PartyCollection ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:PartyCollection. Use adalbert:memberOf hierarchy instead."
+    ] .
+
+adalbertsh:RejectInheritAllowedShape a sh:NodeShape ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+            SELECT ?this WHERE {
+                ?this odrl:inheritAllowed ?v .
+            }
+        """
+    ] ;
+    sh:property [
+        sh:path odrl:inheritAllowed ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:inheritAllowed."
+    ] .
+
+adalbertsh:RejectInheritFromShape a sh:NodeShape ;
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:select """
+            PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+            SELECT ?this WHERE {
+                ?this odrl:inheritFrom ?p .
+            }
+        """
+    ] ;
+    sh:property [
+        sh:path odrl:inheritFrom ;
+        sh:maxCount 0 ;
+        sh:severity sh:Violation ;
+        sh:message "Adalbert does not support odrl:inheritFrom."
+    ] .
+
+# =============================================================================
+# END OF SHAPES
+# =============================================================================

--- a/adalbert-contracts/docs/DATA-CONTRACTS.md
+++ b/adalbert-contracts/docs/DATA-CONTRACTS.md
@@ -1,0 +1,578 @@
+# Adalbert Contracts Guide
+
+A guide for data platform teams using Adalbert for data contracts and subscriptions.
+
+---
+
+## Overview
+
+Adalbert models internal data sharing agreements as ODRL 2.2 policies. A **DataContract** is an offer from a data provider. A **Subscription** is an activated contract binding provider and consumer.
+
+```
+DataContract (Offer)          Subscription (Agreement)
+┌──────────────────┐         ┌──────────────────────┐
+│ Provider duties   │ accept  │ Provider duties       │
+│ Consumer rights   │ ──────> │ Consumer rights       │
+│ Prohibitions      │         │ Consumer duties       │
+│ Recurrence rules  │         │ Prohibitions          │
+└──────────────────┘         │ State tracking         │
+                              └──────────────────────┘
+```
+
+---
+
+## Key Concepts
+
+### DataContract (Offer)
+
+An `adalbert:DataContract` is a subclass of `odrl:Offer`. It specifies:
+
+- **Provider** (`odrl:assigner`): the data team providing data
+- **Target** (`odrl:target`): the data asset(s) covered — inherited by rules unless overridden
+- **Provider duties** (`odrl:obligation` with `adalbert:subject` = provider): SLAs like delivery, notification, schema conformance
+- **Consumer permissions** (`odrl:permission`): what consumers can do with the data
+- **Consumer duties** (`odrl:obligation` without subject in Offer): obligations consumers accept upon subscribing
+- **Prohibitions** (`odrl:prohibition`): what consumers cannot do
+
+### Subscription (Agreement)
+
+An `adalbert:Subscription` is a subclass of `odrl:Agreement`. It adds:
+
+- **Consumer** (`odrl:assignee`): the subscribing team
+- **Effective/expiration dates**: contract period
+- **State tracking**: lifecycle state on duties and the subscription itself
+
+### Provider Duties
+
+Provider duties use DUE actions:
+
+| Action | Description | Example |
+|--------|-------------|---------|
+| `adalbert-due:deliver` | Deliver data to consumers | Daily market data delivery |
+| `adalbert-due:notify` | Send notifications | Schema change notification |
+| `adalbert-due:conformTo` | Maintain conformance to a standard | Schema/quality SLA |
+
+### Consumer Duties
+
+| Action | Description | Example |
+|--------|-------------|---------|
+| `adalbert-due:report` | Submit usage reports | Monthly usage reporting |
+
+### Permissions
+
+Standard ODRL actions apply:
+
+| Action | Description |
+|--------|-------------|
+| `odrl:display` | Display data |
+| `adalbert-due:nonDisplay` | Non-display (algorithmic) use |
+| `odrl:derive` | Create derived products |
+| `odrl:read` | Read data |
+
+---
+
+## Step-by-Step Cookbook
+
+Create your first DataContract in five steps.
+
+### Step 1: Declare the Contract
+
+Every contract starts with a type, profile declaration, and provider identity.
+
+```turtle
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:marketPrices ;
+    adalbert:state adalbert:Active .
+```
+
+### Step 2: Add Provider Duties (SLAs)
+
+Provider duties declare what the data team commits to. The provider is identified by `adalbert:subject` on each duty. Use `adalbert:object` to identify who is affected (e.g., who receives notifications).
+
+Rules inherit `odrl:target` from the policy unless they target a different asset.
+
+```turtle
+    # Daily delivery by 06:30 (target inherited from policy)
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # Schema conformance (different target — not inherited)
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:marketDataSchema
+    ] ;
+```
+
+### Step 3: Add Consumer Permissions
+
+Permissions define what subscribers can do. In an Offer, omit `odrl:assignee` — it is filled when the subscription is created. Target is inherited from the policy.
+
+```turtle
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:display
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:nonDisplay ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internal
+        ]
+    ] ;
+```
+
+### Step 4: Add Consumer Duties and Prohibitions
+
+Consumer duties activate upon subscription. Prohibitions apply to all subscribers.
+
+```turtle
+    # Consumer must report usage monthly (different target — not inherited)
+    odrl:obligation [
+        a odrl:Duty ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:usageStats ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # No external redistribution (target inherited from policy)
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] .
+```
+
+### Step 5: Create a Subscription
+
+When a consumer accepts the contract, create a Subscription (Agreement) referencing the contract:
+
+```turtle
+ex:subscription a adalbert:Subscription ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo ex:contract ;
+    odrl:assigner ex:dataTeam ;
+    odrl:assignee ex:analyticsTeam ;
+    adalbert:effectiveDate "2026-02-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime .
+```
+
+The subscription materializes all duties from the contract with explicit `adalbert:subject` on each.
+
+---
+
+## Provider Duty Patterns
+
+### Timeliness Pattern (Delivery SLA)
+
+Scheduled data delivery with a fulfillment window. Target inherited from policy.
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    adalbert:subject ex:dataTeam ;
+    odrl:action adalbert-due:deliver ;
+    adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+    adalbert:deadline "PT30M"^^xsd:duration
+] .
+```
+
+**DCON equivalent**: `ProviderTimelinessPromise`
+
+### Schema Pattern (Schema Conformance)
+
+Provider guarantees data conforms to a published schema. Target differs from policy — specify explicitly.
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    adalbert:subject ex:dataTeam ;
+    odrl:action adalbert-due:conformTo ;
+    odrl:target ex:marketDataSchema
+] .
+```
+
+**DCON equivalent**: `ProviderSchemaPromise`
+
+### Notification Pattern (Change Notification)
+
+Provider must notify consumers before making changes, with a lead time expressed as a duration deadline. Use `adalbert:object` to identify who is notified.
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    adalbert:subject ex:dataTeam ;
+    adalbert:object ex:consumer ;
+    odrl:action adalbert-due:notify ;
+    odrl:target ex:schemaChanges ;
+    adalbert:deadline "P14D"^^xsd:duration
+] .
+```
+
+**DCON equivalent**: `ProviderChangeNotificationPromise`
+
+### Quality SLA Pattern
+
+Provider guarantees data quality via `conformTo` with a constraint. This replaces DCON's `ProviderQualityPromise`.
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    adalbert:subject ex:dataTeam ;
+    odrl:action adalbert-due:conformTo ;
+    odrl:target ex:riskMetricsSchema ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:timeliness ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand adalbert-due:realtime
+    ]
+] .
+```
+
+The constraint can check any DUE operand — timeliness, classification, environment, etc.
+
+---
+
+## Recurrence
+
+Recurring duties use `adalbert:recurrence` — an RFC 5545 RRULE string. Combined with `adalbert:deadline`, this defines a schedule and fulfillment window.
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    adalbert:subject ex:dataTeam ;
+    odrl:action adalbert-due:deliver ;
+    adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+    adalbert:deadline "PT30M"^^xsd:duration
+] .
+```
+
+This means: deliver market prices daily at 06:00 (target inherited from policy), with a 30-minute window to fulfill.
+
+### Common RRULE Patterns
+
+| Pattern | RRULE |
+|---------|-------|
+| Daily at 06:00 | `FREQ=DAILY;BYHOUR=6;BYMINUTE=0` |
+| Weekly on Monday | `FREQ=WEEKLY;BYDAY=MO` |
+| Monthly on the 1st | `FREQ=MONTHLY;BYMONTHDAY=1` |
+| Every 15 minutes | `FREQ=MINUTELY;INTERVAL=15` |
+| Hourly | `FREQ=HOURLY` |
+
+Each generated instance follows the standard duty lifecycle independently (Pending -> Active -> Fulfilled/Violated).
+
+---
+
+## Common Patterns Quick Reference
+
+### Simple File Drop
+
+Read-only access, no recurrence, no consumer duties. Target inherited from policy.
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:referenceData ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read
+    ] ;
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:modify
+    ] .
+```
+
+### API with SLA
+
+Daily delivery, schema conformance, display + non-display, monthly reporting. Target inherited from policy unless overridden.
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:customerData ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=7;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:customerSchema
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:display
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:nonDisplay
+    ] ;
+    odrl:obligation [
+        a odrl:Duty ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:usageStats ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] .
+```
+
+### Mission-Critical Service
+
+High-frequency delivery with quality SLA and change notification. Target inherited from policy unless overridden.
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:riskMetrics ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=MINUTELY;INTERVAL=1" ;
+        adalbert:deadline "PT30S"^^xsd:duration
+    ] ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:riskSchema ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:timeliness ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:realtime
+        ]
+    ] ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:notify ;
+        odrl:target ex:schemaChanges ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:display
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:nonDisplay
+    ] .
+```
+
+### Multi-Dataset Contract
+
+A single contract covering multiple targets. When a policy has multiple targets, rules must specify their target explicitly — inheritance is ambiguous.
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:marketPrices , ex:referenceData , ex:riskMetrics ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target ex:marketPrices
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target ex:referenceData
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target ex:riskMetrics
+    ] .
+```
+
+---
+
+## Advanced Topics
+
+### Target Inheritance
+
+`odrl:target` at the policy level is inherited by rules that don't declare their own target. This reduces redundancy:
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:target ex:marketPrices ;           # policy-level target
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read                # inherits ex:marketPrices
+    ] ;
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:marketDataSchema      # different target — explicit
+    ] .
+```
+
+**Rules**:
+- Single-target policy: rules inherit the target unless they specify a different one
+- Multi-target policy: rules must specify their target (inheritance is ambiguous)
+- Named duty instances (standalone): always specify their target
+
+### Multi-Asset Contracts
+
+A contract can cover multiple targets. When multiple targets exist, each rule must specify its own target (inheritance is ambiguous):
+
+```turtle
+ex:contract odrl:target ex:asset1 , ex:asset2 ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target ex:asset1
+    ] ;
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:display ;
+        odrl:target ex:asset2
+    ] .
+```
+
+### Team Delegation
+
+Use `adalbert:memberOf` to model team hierarchies. A permission granted to a team applies to its members via hierarchy subsumption during evaluation:
+
+```turtle
+ex:analyst a odrl:Party ;
+    adalbert:memberOf ex:analyticsTeam .
+
+ex:analyticsTeam a odrl:Party ;
+    adalbert:memberOf ex:tradingDivision .
+```
+
+### Version Chains
+
+Use `prov:wasRevisionOf` to link contract versions:
+
+```turtle
+ex:contract-v2 a adalbert:DataContract ;
+    prov:wasRevisionOf ex:contract-v1 .
+
+ex:contract-v3 a adalbert:DataContract ;
+    prov:wasRevisionOf ex:contract-v2 .
+```
+
+Subscriptions reference the specific contract version they activate:
+
+```turtle
+ex:subscription adalbert:subscribesTo ex:contract-v2 .
+```
+
+### Expiration
+
+Contracts and subscriptions can have explicit expiration dates:
+
+```turtle
+ex:subscription a adalbert:Subscription ;
+    adalbert:effectiveDate "2026-01-15T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime .
+```
+
+---
+
+## Lifecycle
+
+Duties and contracts share four states:
+
+```
+         condition true
+Pending ──────────────> Active
+                         |  |
+          action done    |  |  deadline passed
+                         v  v
+                   Fulfilled  Violated
+```
+
+- **Pending**: condition not yet met / not yet in force
+- **Active**: condition met, action required / in force
+- **Fulfilled**: action performed / obligations complete
+- **Violated**: deadline passed / breached
+
+---
+
+## Versioning
+
+Contracts can be versioned using `prov:wasRevisionOf`:
+
+```turtle
+ex:contract-v2 a adalbert:DataContract ;
+    prov:wasRevisionOf ex:contract-v1 .
+```
+
+Subscriptions reference the contract they activate via `adalbert:subscribesTo`:
+
+```turtle
+ex:subscription adalbert:subscribesTo ex:contract-v2 .
+```
+
+---
+
+## Complete Example
+
+See [examples/data-contract.ttl](../examples/data-contract.ttl) for a full working contract with bilateral duties, recurrence, schema conformance, and subscription.
+
+For comprehensive test data covering all patterns, see [examples/baseline.ttl](../examples/baseline.ttl).
+
+---
+
+## DCON Migration
+
+If migrating from DCON, see [adalbert-term-mapping.md](adalbert-term-mapping.md) for complete property equivalents and [comparisons/comparison-dcon.md](comparisons/comparison-dcon.md) for the supersession analysis.
+
+---
+
+## Validation Checklist
+
+1. Every policy declares `odrl:profile <https://vocabulary.bigbank/adalbert/>` and `<https://vocabulary.bigbank/adalbert/due/>`
+2. Conflict strategy (`odrl:conflict odrl:prohibit`) is inherited from the profile — do not repeat per-policy
+3. DataContract has `odrl:assigner` (provider)
+4. Subscription has both `odrl:assigner` and `odrl:assignee`
+5. Subscription has `adalbert:subscribesTo` referencing a DataContract
+6. Each duty has exactly one `odrl:action`
+7. Each permission and prohibition has exactly one `odrl:action` and one `odrl:target`
+8. Provider duties have `adalbert:subject` set to the provider
+9. Deadlines use `xsd:dateTime` or `xsd:duration`
+10. Recurrence uses a valid RFC 5545 RRULE starting with `FREQ=`
+11. Constraints have `leftOperand`, `operator`, and `rightOperand`
+12. LogicalConstraints use exactly one of `odrl:and`, `odrl:or`, or `adalbert:not`
+13. Validate against SHACL shapes:
+
+```bash
+shacl validate --shapes ontology/adalbert-shacl.ttl --data my-contract.ttl
+```

--- a/adalbert-contracts/docs/DATA-USE-POLICIES.md
+++ b/adalbert-contracts/docs/DATA-USE-POLICIES.md
@@ -1,0 +1,551 @@
+# Adalbert Policy Writers Guide
+
+A guide for data stewards writing data use policies with Adalbert.
+
+---
+
+## 1. When to Use Policies vs Contracts
+
+Adalbert supports two document types for different purposes:
+
+| Type | ODRL Base | Use Case | Parties |
+|------|-----------|----------|---------|
+| **Policy** (`odrl:Set`) | Set | Organizational rules, access controls | None (applies to anyone matching constraints) |
+| **Offer / Contract** (`adalbert:DataContract`) | Offer | Bilateral agreements between teams | Provider (assigner) required |
+| **Subscription** (`adalbert:Subscription`) | Agreement | Activated contract | Both parties required |
+
+Use **policies** (`odrl:Set`) when:
+- Writing organizational data governance rules
+- Defining access controls by role, purpose, or classification
+- Setting restrictions that apply universally (no specific consumer)
+- Encoding regulatory requirements (GDPR, data residency)
+
+Use **contracts** when two specific teams need a bilateral agreement with SLAs. See [contracts-guide.md](contracts-guide.md) for contract authoring.
+
+---
+
+## 2. Quick Start
+
+A minimal data use policy:
+
+```turtle
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+
+ex:policy a odrl:Set ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:target ex:customerData ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee ex:analyticsTeam ;
+        odrl:action odrl:read ;
+        odrl:target ex:customerData ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:analytics
+        ]
+    ] ;
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute ;
+        odrl:target ex:customerData
+    ] .
+```
+
+This policy says: the analytics team may read customer data for analytics purposes, and no one may distribute it.
+
+---
+
+## 3. Permission Patterns
+
+### Purpose-Restricted Permission
+
+Grant access only for a specific purpose.
+
+```turtle
+odrl:permission [
+    a odrl:Permission ;
+    odrl:assignee ex:complianceTeam ;
+    odrl:action odrl:read ;
+    odrl:target ex:transactionData ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand odrl:purpose ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand adalbert-due:compliance
+    ]
+] .
+```
+
+### Classification-Based Permission
+
+Grant access based on the data's classification level.
+
+```turtle
+odrl:permission [
+    a odrl:Permission ;
+    odrl:action odrl:read ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:classification ;
+        odrl:operator odrl:isAnyOf ;
+        odrl:rightOperand (adalbert-due:public adalbert-due:internal)
+    ]
+] .
+```
+
+### Role-Based Permission
+
+Grant access based on the requesting agent's role.
+
+```turtle
+odrl:permission [
+    a odrl:Permission ;
+    odrl:action odrl:read ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:role ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand "data-analyst"
+    ]
+] .
+```
+
+### Time-Limited Permission
+
+Grant access only before a certain date.
+
+```turtle
+odrl:permission [
+    a odrl:Permission ;
+    odrl:action odrl:read ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert:currentDateTime ;
+        odrl:operator odrl:lt ;
+        odrl:rightOperand "2026-12-31T23:59:59Z"^^xsd:dateTime
+    ]
+] .
+```
+
+---
+
+## 4. Prohibition Patterns
+
+### No External Distribution
+
+```turtle
+odrl:prohibition [
+    a odrl:Prohibition ;
+    odrl:action odrl:distribute ;
+    odrl:target ex:data
+] .
+```
+
+### No PII Processing
+
+Prohibit use of data classified as PII for certain processing modes.
+
+```turtle
+odrl:prohibition [
+    a odrl:Prohibition ;
+    odrl:action odrl:use ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:LogicalConstraint ;
+        odrl:and (
+            [
+                a odrl:Constraint ;
+                odrl:leftOperand adalbert-due:sensitivity ;
+                odrl:operator odrl:eq ;
+                odrl:rightOperand adalbert-due:pii
+            ]
+            [
+                a odrl:Constraint ;
+                odrl:leftOperand adalbert-due:processingMode ;
+                odrl:operator odrl:eq ;
+                odrl:rightOperand adalbert-due:modelTraining
+            ]
+        )
+    ]
+] .
+```
+
+### No Commingling
+
+Prohibit mixing data with other sources.
+
+```turtle
+odrl:prohibition [
+    a odrl:Prohibition ;
+    odrl:action odrl:derive ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:derivationType ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand adalbert-due:commingled
+    ]
+] .
+```
+
+---
+
+## 5. Constraint Patterns
+
+Constraints restrict when rules apply. An `odrl:Constraint` has three parts:
+
+| Part | Property | Description |
+|------|----------|-------------|
+| Left operand | `odrl:leftOperand` | What to check (from DUE vocabulary) |
+| Operator | `odrl:operator` | How to compare (`eq`, `neq`, `lt`, `gt`, `lteq`, `gteq`, `isAnyOf`, `isNoneOf`, `isAllOf`) |
+| Right operand | `odrl:rightOperand` | Expected value(s) |
+
+### Purpose Constraint
+
+```turtle
+odrl:constraint [
+    a odrl:Constraint ;
+    odrl:leftOperand odrl:purpose ;
+    odrl:operator odrl:eq ;
+    odrl:rightOperand adalbert-due:analytics
+] .
+```
+
+### Classification Constraint
+
+```turtle
+odrl:constraint [
+    a odrl:Constraint ;
+    odrl:leftOperand adalbert-due:classification ;
+    odrl:operator odrl:eq ;
+    odrl:rightOperand adalbert-due:confidential
+] .
+```
+
+### Jurisdiction Constraint
+
+```turtle
+odrl:constraint [
+    a odrl:Constraint ;
+    odrl:leftOperand adalbert-due:jurisdiction ;
+    odrl:operator odrl:isAnyOf ;
+    odrl:rightOperand ("US" "UK" "EU")
+] .
+```
+
+### Retention Constraint
+
+```turtle
+odrl:constraint [
+    a odrl:Constraint ;
+    odrl:leftOperand adalbert-due:retentionPeriod ;
+    odrl:operator odrl:lteq ;
+    odrl:rightOperand "P7Y"^^xsd:duration
+] .
+```
+
+### Environment Constraint
+
+```turtle
+odrl:constraint [
+    a odrl:Constraint ;
+    odrl:leftOperand adalbert-due:environment ;
+    odrl:operator odrl:eq ;
+    odrl:rightOperand adalbert-due:production
+] .
+```
+
+---
+
+## 6. DUE Operands Quick Reference
+
+All operands are `odrl:LeftOperand` with `adalbert:resolutionPath`.
+
+### Agent Operands (resolved from requesting agent)
+
+| Operand | Resolution Path | Values / Type |
+|---------|----------------|---------------|
+| `adalbert-due:role` | `agent.role` | String |
+| `adalbert-due:organization` | `agent.organization` | IRI |
+| `adalbert-due:costCenter` | `agent.costCenter` | String |
+| `adalbert-due:recipientType` | `agent.recipientType` | `internal`, etc. |
+
+### Asset Operands (resolved from target asset)
+
+| Operand | Resolution Path | Values / Type |
+|---------|----------------|---------------|
+| `adalbert-due:classification` | `asset.classification` | `public`, `internal`, `confidential`, `restricted` |
+| `adalbert-due:sensitivity` | `asset.sensitivity` | `pii`, `mnpi`, `phi` |
+| `adalbert-due:assetClass` | `asset.class` | String (equity, fx, etc.) |
+| `adalbert-due:market` | `asset.market` | String (NYSE, LSE, etc.) |
+| `adalbert-due:isBenchmark` | `asset.isBenchmark` | Boolean |
+| `adalbert-due:residency` | `asset.residency` | String (country) |
+| `adalbert-due:retentionPeriod` | `asset.retentionPeriod` | `xsd:duration` |
+| `adalbert-due:expiry` | `asset.expiry` | `xsd:dateTime` |
+| `adalbert-due:timeliness` | `asset.timeliness` | `realtime`, `nearRealtime`, `delayed`, `endOfDay`, `historical` |
+| `adalbert-due:delayMinutes` | `asset.delayMinutes` | Integer |
+| `adalbert-due:auditRequired` | `asset.auditRequired` | Boolean |
+
+### Context Operands (resolved from request context)
+
+| Operand | Resolution Path | Values / Type |
+|---------|----------------|---------------|
+| `odrl:purpose` | `context.purpose` | `analytics`, `research`, `compliance`, `operations` |
+| `adalbert-due:jurisdiction` | `context.jurisdiction` | String (country) |
+| `adalbert-due:environment` | `context.environment` | `production`, `staging`, `development`, `sandbox` |
+| `adalbert-due:network` | `context.network` | `internalNetwork`, `externalNetwork`, `cloudNetwork` |
+| `adalbert-due:processingMode` | `context.processingMode` | `human`, `automated`, `modelTraining`, `inference` |
+| `adalbert-due:legalBasis` | `context.legalBasis` | `consent`, `contract`, `legalObligation`, `vitalInterest`, `publicTask`, `legitimateInterest` |
+| `adalbert-due:consentId` | `context.consentId` | String |
+| `adalbert-due:accessPattern` | `context.accessPattern` | `batch`, `streaming`, `interactive`, `api` |
+| `adalbert-due:volumeLimit` | `context.volumeLimit` | Integer |
+| `adalbert-due:rateLimit` | `context.rateLimit` | Integer |
+| `adalbert-due:derivationType` | `context.derivationType` | `commingled`, `nonSubstitutive`, `newProduct` |
+| `adalbert-due:project` | `context.project` | String |
+
+---
+
+## 7. DUE Actions Quick Reference
+
+### ODRL Common Vocabulary (used directly)
+
+| Action | Definition | Hierarchy |
+|--------|------------|-----------|
+| `odrl:use` | General use | Top |
+| `odrl:read` | Read/view | `includedIn use` |
+| `odrl:display` | Display to users | `includedIn use` |
+| `odrl:distribute` | Distribute to third parties | `includedIn use` |
+| `odrl:delete` | Delete the asset | `includedIn use` |
+| `odrl:modify` | Modify the asset | `includedIn use` |
+| `odrl:aggregate` | Aggregate with other data | `includedIn use` |
+| `odrl:anonymize` | Remove identifying info | `includedIn use` |
+| `odrl:derive` | Create derived data | `includedIn use` |
+
+### DUE-Specific Actions
+
+| Action | Definition | Parent |
+|--------|------------|--------|
+| `adalbert-due:nonDisplay` | Automated/programmatic use | `use` |
+| `adalbert-due:conformTo` | Conform to schema/spec | None |
+| `adalbert-due:log` | Log access | `inform` |
+| `adalbert-due:notify` | Notify parties | `inform` |
+| `adalbert-due:report` | Submit reports | `inform` |
+| `adalbert-due:deliver` | Deliver data | `distribute` |
+| `adalbert-due:query` | Query/select | `read` |
+| `adalbert-due:export` | Export outside system | `distribute` |
+| `adalbert-due:copy` | Copy to another location | `reproduce` |
+| `adalbert-due:link` | Link/join datasets | `aggregate` |
+| `adalbert-due:profile` | Create profiles | `derive` |
+| `adalbert-due:calculateIndex` | Index calculation | `derive` |
+| `adalbert-due:algorithmicTrading` | Automated trading | `nonDisplay` |
+
+Action hierarchy uses `odrl:includedIn`. A permission on `odrl:use` implicitly permits all actions below it.
+
+---
+
+## 8. Combining Constraints
+
+### Logical AND
+
+All conditions must be true. Use `odrl:LogicalConstraint` with `odrl:and`:
+
+```turtle
+odrl:constraint [
+    a odrl:LogicalConstraint ;
+    odrl:and (
+        [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:compliance
+        ]
+        [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:legalBasis ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:legitimateInterest
+        ]
+    )
+] .
+```
+
+### Logical OR
+
+At least one condition must be true. Use `odrl:or`:
+
+```turtle
+odrl:constraint [
+    a odrl:LogicalConstraint ;
+    odrl:or (
+        [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:compliance
+        ]
+        [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:operations
+        ]
+    )
+] .
+```
+
+### Logical NOT
+
+Negate a constraint. Use `adalbert:not`:
+
+```turtle
+odrl:constraint [
+    a odrl:LogicalConstraint ;
+    adalbert:not [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:environment ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand adalbert-due:production
+    ]
+] .
+```
+
+This means: the constraint is satisfied when the environment is **not** production.
+
+A `LogicalConstraint` must have exactly one of `odrl:and`, `odrl:or`, or `adalbert:not`.
+
+---
+
+## 9. Common Policy Patterns
+
+### Internal Analytics Only
+
+```turtle
+ex:policy a odrl:Set ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:target ex:data ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target ex:data ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand odrl:purpose ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand adalbert-due:analytics
+                ]
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:recipientType ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand adalbert-due:internal
+                ]
+            )
+        ]
+    ] ;
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute ;
+        odrl:target ex:data
+    ] .
+```
+
+### Jurisdiction-Restricted
+
+```turtle
+odrl:permission [
+    a odrl:Permission ;
+    odrl:action odrl:read ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:jurisdiction ;
+        odrl:operator odrl:isAnyOf ;
+        odrl:rightOperand ("US" "UK")
+    ]
+] .
+```
+
+### Retention-Limited
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    odrl:action odrl:delete ;
+    odrl:target ex:data ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:retentionPeriod ;
+        odrl:operator odrl:gt ;
+        odrl:rightOperand "P5Y"^^xsd:duration
+    ]
+] .
+```
+
+### Audit-Required
+
+```turtle
+odrl:obligation [
+    a odrl:Duty ;
+    odrl:action adalbert-due:log ;
+    odrl:target ex:accessLog ;
+    odrl:constraint [
+        a odrl:Constraint ;
+        odrl:leftOperand adalbert-due:classification ;
+        odrl:operator odrl:eq ;
+        odrl:rightOperand adalbert-due:confidential
+    ] ;
+    adalbert:deadline "PT1H"^^xsd:duration
+] .
+```
+
+---
+
+## 10. Policy Review Checklist
+
+1. Every policy declares `odrl:profile <https://vocabulary.bigbank/adalbert/>` and `<https://vocabulary.bigbank/adalbert/due/>`
+2. Conflict strategy (`odrl:conflict odrl:prohibit`) is inherited from the profile — do not repeat per-policy
+3. Policy has at least one `odrl:target`
+4. Each permission and prohibition has exactly one `odrl:action` and one effective `odrl:target` — either declared on the rule or inherited from the policy-level target (rule-level `odrl:target` may be omitted when a policy-level target exists)
+5. Each duty has exactly one `odrl:action`
+6. Each constraint has `leftOperand`, `operator`, and `rightOperand`
+7. LogicalConstraints use exactly one of `odrl:and`, `odrl:or`, or `adalbert:not`
+8. Resolution paths match canonical roots (`agent.`, `asset.`, `context.`)
+9. Prohibitions cover the intended restrictions (prohibition overrides permission)
+10. Duties have appropriate deadlines where time-sensitive
+11. Classification and sensitivity values match the DUE vocabulary
+12. Validate against SHACL shapes:
+
+```bash
+shacl validate --shapes ontology/adalbert-shacl.ttl --data my-policy.ttl
+```
+
+---
+
+## Further Reading
+
+- [adalbert-overview.md](adalbert-overview.md) — What is Adalbert?
+- [adalbert-specification.md](adalbert-specification.md) — Technical vocabulary reference
+- [adalbert-term-mapping.md](adalbert-term-mapping.md) — Business term -> property mapping
+- [examples/data-use-policy.ttl](../examples/data-use-policy.ttl) — Complete working policy example
+- [examples/baseline.ttl](../examples/baseline.ttl) — Comprehensive test data
+
+---
+
+**Version**: 0.7 | **Date**: 2026-02-04

--- a/adalbert-contracts/docs/DPROD-Adalbert-Comparison.md
+++ b/adalbert-contracts/docs/DPROD-Adalbert-Comparison.md
@@ -1,0 +1,207 @@
+# DPROD-Contracts vs Adalbert: Comparison Report
+
+A comparison of the two ODRL-based data contract approaches contributed to EKGF/dprod.
+
+---
+
+## Overview
+
+Both `dprod-contracts` and `adalbert-contracts` extend ODRL 2.2 for data governance. They share the same goal — formalizing bilateral data agreements between providers and consumers — but differ in scope, architecture, and formality.
+
+| Dimension | dprod-contracts | adalbert-contracts |
+|---|---|---|
+| **Scope** | Data contracts only | Data contracts + data-use policies |
+| **ODRL relationship** | Custom Rule subclass (Promise) | Proper ODRL 2.2 profile (Duty, Permission, Prohibition) |
+| **Formal semantics** | No | Yes (normative, verification-ready) |
+| **Lifecycle** | 4 statuses (Pending, Active, Expired, Cancelled) | 4 states (Pending, Active, Fulfilled, Violated) with formal transitions |
+| **Bilateral duties** | Via ProviderPromise / ConsumerPromise | Via `adalbert:subject` / `adalbert:object` on standard `odrl:Duty` |
+| **Recurrence** | `dprod:ICalSchedule` class + `dprod:icalRule` | `adalbert:recurrence` property (direct RRULE string on Duty) |
+| **Validation** | SHACL shapes | SHACL shapes |
+| **W3C Profile declaration** | ODRL Profile in ontology | Separate W3C DXPROF declaration |
+
+---
+
+## Architectural Differences
+
+### 1. Promise vs Duty
+
+**dprod-contracts** introduces `dprod:Promise` as a new `odrl:Rule` subclass, disjoint with `odrl:Duty`, `odrl:Permission`, and `odrl:Prohibition`. This creates a parallel class hierarchy:
+
+```
+odrl:Rule
+├── odrl:Permission
+├── odrl:Prohibition
+├── odrl:Duty
+└── dprod:Promise          ← new Rule type
+    ├── dprod:ProviderPromise
+    │   ├── dprod:ProviderTimelinessPromise
+    │   ├── dprod:ProviderSchemaPromise
+    │   ├── dprod:ProviderServiceLevelPromise
+    │   └── ...
+    └── dprod:ConsumerPromise
+```
+
+**Adalbert** uses standard `odrl:Duty` for all obligations, distinguishing provider from consumer duties via `adalbert:subject`:
+
+```
+odrl:Rule (unchanged)
+├── odrl:Permission
+├── odrl:Prohibition
+└── odrl:Duty
+    ├── with adalbert:subject = provider  → provider duty
+    └── with adalbert:subject = consumer  → consumer duty
+```
+
+**Implication**: Adalbert policies are valid ODRL 2.2 — any ODRL processor can partially understand them. dprod-contracts requires Promise-aware processing.
+
+### 2. Data-Use Policies
+
+**dprod-contracts** focuses exclusively on bilateral contracts between named parties.
+
+**Adalbert** also supports `odrl:Set` policies — organizational rules that apply to anyone matching constraints:
+
+- Role-based access control
+- Purpose restrictions
+- Classification-based permissions
+- Environment constraints
+- Jurisdiction requirements
+- Retention limits
+
+This is a key differentiator. Real-world data governance requires both contracts (bilateral) and policies (organizational).
+
+### 3. Formal Semantics
+
+**dprod-contracts** defines classes and properties but not evaluation behavior.
+
+**Adalbert** includes a normative formal semantics document defining:
+
+- `Eval : Request × PolicySet × State → Decision × DutySet` (total function)
+- Deterministic conflict resolution (Prohibition > Permission)
+- Duty lifecycle state machine (Pending → Active → Fulfilled/Violated)
+- Operand resolution from canonical roots (agent, asset, context)
+- Recurrence expansion via RFC 5545 RRULE
+
+This makes Adalbert amenable to formal verification (Dafny, Why3, Coq).
+
+### 4. Recurrence
+
+**dprod-contracts**:
+```turtle
+dprod:hasSchedule [
+    a dprod:ICalSchedule ;
+    dprod:icalRule "FREQ=DAILY;BYHOUR=6;BYMINUTE=0"
+] .
+```
+
+**Adalbert**:
+```turtle
+adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+adalbert:deadline "PT30M"^^xsd:duration .
+```
+
+Adalbert is more concise (property on Duty vs. nested class) and adds `deadline` for the per-instance fulfillment window.
+
+### 5. Operand Resolution
+
+**dprod-contracts** does not define how constraint operands resolve.
+
+**Adalbert** defines `adalbert:resolutionPath` — dot-separated paths from canonical roots:
+
+```
+agent.role, agent.organization, agent.costCenter
+asset.classification, asset.market, asset.isBenchmark
+context.purpose, context.environment, context.legalBasis
+```
+
+This enables deterministic constraint evaluation across implementations.
+
+---
+
+## Mapping Table
+
+### Classes
+
+| dprod-contracts | Adalbert | Notes |
+|---|---|---|
+| `dprod:DataContract` | `adalbert:DataContract` | Both subclass `odrl:Agreement` / `odrl:Offer` |
+| `dprod:DataOffer` | `adalbert:DataContract` | Adalbert DataContract is an Offer; Subscription is the Agreement |
+| `dprod:Promise` | `odrl:Duty` | Standard ODRL type |
+| `dprod:ProviderPromise` | `odrl:Duty` + `adalbert:subject` | Subject identifies provider |
+| `dprod:ConsumerPromise` | `odrl:Permission` / `odrl:Prohibition` / `odrl:Duty` | Split by semantics |
+| `dprod:ProviderTimelinessPromise` | `odrl:Duty` + `adalbert-due:deliver` + `adalbert:recurrence` | |
+| `dprod:ProviderSchemaPromise` | `odrl:Duty` + `adalbert-due:conformTo` | |
+| `dprod:ProviderServiceLevelPromise` | `odrl:Duty` + `adalbert-due:conformTo` + constraints | |
+| `dprod:ServiceLevelTarget` | `odrl:Constraint` | Expressed as constraint on duty |
+| `dprod:ICalSchedule` | `adalbert:recurrence` (string property) | Simpler, same RRULE syntax |
+
+### Properties
+
+| dprod-contracts | Adalbert | Notes |
+|---|---|---|
+| `dprod:contractStatus` | `adalbert:state` | Similar lifecycle, different value names |
+| `dprod:providerPromise` | `odrl:obligation` | Standard ODRL property |
+| `dprod:consumerPromise` | `odrl:permission` / `odrl:obligation` / `odrl:prohibition` | Split by semantics |
+| `dprod:hasSchedule` / `dprod:icalRule` | `adalbert:recurrence` | Direct RRULE on Duty |
+| `dprod:hasEffectivePeriod` | `adalbert:effectiveDate` + `adalbert:expirationDate` | |
+| `dprod:noticePeriod` | `adalbert:deadline` | Duration on notification duty |
+| `dprod:supersedes` | `prov:wasRevisionOf` | Standard provenance |
+| `dprod:hasServiceLevelTarget` | `odrl:constraint` on duty | |
+| `dprod:hasPricing` | Not in scope | Adalbert focuses on rights, not pricing |
+
+### Actions
+
+| dprod-contracts | Adalbert | Notes |
+|---|---|---|
+| `dprod:deliverOnSchedule` | `adalbert-due:deliver` | `includedIn odrl:distribute` |
+| `dprod:maintainSchema` | `adalbert-due:conformTo` | Duty-only action |
+| `dprod:maintainQuality` | `adalbert-due:conformTo` + constraint | Quality as constrained conformance |
+| `dprod:notifyChange` | `adalbert-due:notify` | `includedIn odrl:inform` |
+| `dprod:notifyTermination` | `adalbert-due:notify` + `adalbert:deadline` | Deadline = notice period |
+| `dprod:meetServiceLevel` | `adalbert-due:conformTo` + constraints | SLA as constrained conformance |
+| `dprod:provideSupport` | `adalbert-due:notify` | Best fit |
+| `dprod:reportUsage` | `adalbert-due:report` | `includedIn odrl:inform` |
+| `dprod:query` | `adalbert-due:query` | `includedIn odrl:read` |
+| `dprod:access` | `odrl:use` | Standard ODRL |
+| `dprod:deriveInsights` | `odrl:derive` | Standard ODRL |
+| `dprod:aggregate` | `odrl:aggregate` | Standard ODRL |
+| `dprod:anonymize` | `odrl:anonymize` | Standard ODRL |
+| `dprod:shareInternally` | `odrl:distribute` + constraint | Internal-only via constraint |
+| `dprod:restrictPurpose` | `odrl:Prohibition` on `odrl:distribute` | Prohibition, not action |
+| `dprod:deleteOnExpiry` | `odrl:Duty` with `odrl:delete` | Standard ODRL action |
+
+### Status Values
+
+| dprod-contracts | Adalbert | Notes |
+|---|---|---|
+| `dprod:ContractStatusPending` | `adalbert:Pending` | Same semantics |
+| `dprod:ContractStatusActive` | `adalbert:Active` | Same semantics |
+| `dprod:ContractStatusExpired` | `adalbert:Fulfilled` | Adalbert: natural completion = Fulfilled |
+| `dprod:ContractStatusCancelled` | `adalbert:Violated` | Adalbert: early termination = Violated |
+
+---
+
+## What Adalbert Adds Beyond dprod-contracts
+
+1. **Data-use policies** (`odrl:Set`) — organizational rules, access controls, not just bilateral contracts
+2. **Formal semantics** — total evaluation function, deterministic conflict resolution, verifiable
+3. **Duty lifecycle** — formal state machine with Pending → Active → Fulfilled/Violated transitions
+4. **Structured operand resolution** — `resolutionPath` from canonical roots (agent, asset, context)
+5. **Rich constraint vocabulary** — 33 operands across purpose, classification, jurisdiction, environment, timeliness, SLA metrics, data quality, channels, subscription tiers, legal basis, etc.
+6. **Logical negation** — `adalbert:not` (ODRL lacks this)
+7. **Target inheritance** — policy-level `odrl:target` inherited by rules
+8. **Party hierarchies** — `adalbert:partOf` (assets) and `adalbert:memberOf` (parties) with transitivity
+
+## What dprod-contracts Adds Beyond Adalbert
+
+1. **Pricing** — `dprod:hasPricing` with `schema:PriceSpecification` (marketplace scenarios). Adalbert intentionally does not address pricing, focusing on rights and obligations.
+2. **Promise class hierarchy** — richer typing for different commitment types (may aid discovery)
+
+---
+
+## Translated Examples
+
+See `examples/dprod-translated.ttl` for all 8 dprod-contracts examples translated to Adalbert, demonstrating that Adalbert can express the same contracts while adding lifecycle tracking, deterministic evaluation, and structured constraints.
+
+---
+
+**Version**: 0.7 | **Date**: 2026-02-16

--- a/adalbert-contracts/docs/SEMANTICS.md
+++ b/adalbert-contracts/docs/SEMANTICS.md
@@ -1,0 +1,1127 @@
+---
+title: "Adalbert Formal Semantics"
+subtitle: "Deterministic Policy Evaluation for Data Governance"
+version: "0.7"
+status: "Draft"
+date: 2026-02-03
+abstract: |
+  Adalbert is a proper ODRL 2.2 profile with deterministic, total evaluation
+  semantics and bilateral agreement support. This document specifies the formal
+  semantics in a style amenable to mechanization in Dafny, Why3, or similar
+  verification frameworks.
+---
+
+## 1. Introduction
+
+Adalbert addresses semantic gaps in ODRL 2.2:
+
+1. **Duty Ambiguity**: ODRL conflates pre-conditions with post-obligations
+2. **Unilateral Agreements**: ODRL evaluates only from assignee perspective
+3. **Undefined States**: ODRL permits evaluation to be "undefined"
+
+Adalbert provides:
+
+- Explicit duty lifecycle with state machine semantics
+- Bilateral agreement evaluation (grantor and grantee duties)
+- Total evaluation functions (always terminate with defined result)
+- Clear separation of Condition (pre-requisite) from Duty (obligation)
+- Path-based operand resolution with formal grammar and security constraints
+
+### 1.1 Scope and Runtime Boundary
+
+This specification defines **evaluation semantics** — the contract a conformant engine
+must satisfy. The `State` parameter in `Eval` is an opaque input provided by the
+runtime environment. Adalbert specifies what decision and state transitions *should*
+result from evaluation, but does not define:
+
+- How `State` is persisted or managed between evaluations
+- Event-driven triggers for duty activation or deadline enforcement
+- Protocols for requirement fulfillment claims or re-evaluation
+
+These operational concerns are out of scope for a declarative policy profile.
+Implementations requiring runtime state management, event processing, and enforcement
+protocols should consult RL2, which extends Adalbert's evaluation semantics with a
+complete operational protocol layer.
+
+### 1.2 Notation
+
+- `×` for Cartesian product
+- `→` for function types
+- `∪` for union
+- `∈` for set membership
+- `⊥` for undefined/bottom value
+- `⟦e⟧` for denotation of expression `e`
+- `Γ ⊢ e : τ` for typing judgement ("in context Γ, expression e has type τ")
+
+### 1.2 Document Status
+
+This document is **normative** for Adalbert implementations.
+
+---
+
+## 2. Type System
+
+The type system ensures well-formed policies.
+
+### 2.1 Typing Judgements
+
+We use:
+
+```
+Γ ⊢ e : τ
+```
+
+Where Γ is a typing context mapping identifiers to types.
+
+### 2.2 Types
+
+```
+τ ::= Agent | Action | Asset | Condition | Time | Duration | Boolean | Value | Norm | State | Policy
+```
+
+### 2.3 Key Typing Rules
+
+Permission:
+
+```
+Γ ⊢ a : Agent     Γ ⊢ x : Action     Γ ⊢ s : Asset     Γ ⊢ c : Condition
+---------------------------------------------------------------------------
+       Γ ⊢ Permission(a, x, s, c) : Norm
+```
+
+Duty:
+
+```
+Γ ⊢ a : Agent     Γ ⊢ x : Action     Γ ⊢ s : Asset
+Γ ⊢ c : Condition     Γ ⊢ dl : Deadline     Γ ⊢ r : Recurrence
+--------------------------------------------------------------------------
+        Γ ⊢ Duty(a, x, s, c, dl, r) : Norm
+```
+
+Prohibition:
+
+```
+Γ ⊢ a : Agent     Γ ⊢ x : Action     Γ ⊢ s : Asset     Γ ⊢ c : Condition
+---------------------------------------------------------------------------
+   Γ ⊢ Prohibition(a, x, s, c) : Norm
+```
+
+AtomicConstraint:
+
+```
+Γ ⊢ left : LeftOperand     Γ ⊢ op : ComparisonOperator     Γ ⊢ right : Value
+-------------------------------------------------------------------------------
+        Γ ⊢ AtomicConstraint(left, op, right) : Condition
+```
+
+Logical connectives follow standard typing rules for Boolean-valued expressions.
+
+---
+
+## 3. Abstract Syntax
+
+We define Adalbert's abstract syntax using a typed algebraic grammar.
+
+### 3.1 Syntactic Domains
+
+| Domain | Symbol | Description |
+|--------|--------|-------------|
+| Agents | **A** | Set of agent identifiers |
+| Actions | **X** | Set of action identifiers |
+| Assets | **S** | Set of asset identifiers |
+| Values | **V** | Set of atomic values (strings, numbers, URIs) |
+| Time | **T** | Time domain (ISO 8601 instants) |
+| Duration | **D** | Duration domain (ISO 8601 durations) |
+
+### 3.2 Norms
+
+```
+Norm ::= Permission(subject: Agent, action: Action, asset: Asset, condition: Condition?)
+       | Duty(subject: Agent, action: Action, asset: Asset,
+              object: Agent?, condition: Condition?, deadline: Deadline?, recurrence: Recurrence?)
+       | Prohibition(subject: Agent, action: Action, asset: Asset, condition: Condition?)
+
+Deadline ::= AbsoluteDeadline(time: Time)
+           | RelativeDeadline(duration: Duration)
+
+Recurrence ::= RRule(rule: String)
+```
+
+**Notes**:
+
+- `Permission` corresponds to `odrl:Permission`; `Prohibition` to `odrl:Prohibition`; `Duty` to `odrl:Duty`.
+- The formal `subject` parameter maps to `adalbert:subject` on duties (rdfs:subPropertyOf `odrl:assignee`) and to `odrl:assignee` on permissions/prohibitions.
+- The formal `object` parameter (duties only) maps to `adalbert:object` — the party affected by the duty action (e.g., who is notified). Not used in norm matching.
+- `AbsoluteDeadline`: Fixed point in time (e.g., 2026-12-31T23:59:59Z)
+- `RelativeDeadline`: Duration from activation (e.g., P30D, PT24H)
+
+**Abstract-to-RDF Name Mapping**:
+
+| Abstract Syntax | RDF Encoding | Notes |
+|---|---|---|
+| `Permission` | `odrl:Permission` | |
+| `Duty` | `odrl:Duty` | |
+| `Prohibition` | `odrl:Prohibition` | |
+| `subject` (Permission/Prohibition) | `odrl:assignee` | Party to whom the norm applies |
+| `subject` (Duty) | `adalbert:subject` | Party bearing the duty (rdfs:subPropertyOf odrl:assignee) |
+| `object` (Duty) | `adalbert:object` | Party affected by the duty action (metadata, not used in matching) |
+| `grantor` | `odrl:assigner` | Party granting rights |
+| `grantee` | `odrl:assignee` | Party receiving rights (policy-level) |
+| `condition` | `odrl:constraint` | |
+| `Set` | `odrl:Set` | |
+| `Offer` | `odrl:Offer` | `DataContract` is a subtype |
+| `Agreement` | `odrl:Agreement` | `Subscription` is a subtype |
+| `lte` | `odrl:lteq` | |
+| `gte` | `odrl:gteq` | |
+| `recurrence` | `adalbert:recurrence` | RFC 5545 RRULE string |
+
+### 3.3 Conditions
+
+```
+Condition ::= AtomicConstraint(leftOperand: LeftOperand,
+                               operator: ComparisonOperator,
+                               rightOperand: Value)
+            | And(operands: Condition+)
+            | Or(operands: Condition+)
+            | Not(operand: Condition)
+
+ComparisonOperator ::= eq | neq | lt | lte | gt | gte | isAnyOf | isNoneOf
+
+RuntimeRef ::= currentAgent | currentDateTime
+```
+
+**Notes**:
+
+- `leftOperand` is drawn from profile-defined operands with `resolutionPath`, or dual-typed `RuntimeReference` operands (e.g., `currentDateTime`)
+- Dynamic value resolution on the left side uses `LeftOperand` with `adalbert:resolutionPath` or dual-typed `RuntimeReference` operands resolved via `resolveRuntime`
+- Right operands are literal values. Identity binding via runtime references in right-operand position is deferred to RL2 (`rl2:rightOperandRef`)
+
+### 3.4 Policies
+
+```
+Policy ::= Set(target: Asset?, clauses: Norm+, condition: Condition?)
+         | Offer(grantor: Agent, grantee: Agent?, target: Asset?, clauses: Norm+, condition: Condition?)
+         | Agreement(grantor: Agent, grantee: Agent, target: Asset?, clauses: Norm+, condition: Condition?)
+```
+
+**Notes**:
+
+- `Set`: Unilateral declaration, no parties. Maps to `odrl:Set` in the RDF encoding.
+- `Offer`: Proposal from grantor, grantee optional (open offer). Maps to `odrl:Offer`. `DataContract` is a subtype of `Offer`.
+- `Agreement`: Bilateral binding, both parties identified. Maps to `odrl:Agreement`. `Subscription` is a subtype of `Agreement`.
+- The formal `grantor` parameter maps to `odrl:assigner` (the party granting rights) in the RDF encoding.
+- The formal `grantee` parameter maps to `odrl:assignee` (the party receiving rights) in the RDF encoding.
+
+### 3.5 Requests
+
+```
+Request ::= Request(agent: Agent, action: Action, asset: Asset, context: Context)
+
+Context ::= Map<String, Value>
+```
+
+**Note**: Context keys correspond to the second segment of resolution paths (e.g., the path `context.purpose` resolves by looking up `"purpose"` in `Context`).
+
+---
+
+## 4. Semantic Domains
+
+### 4.1 State
+
+```
+Σ = {
+    clock       : Time,
+    state       : Duty → State,
+    activatedAt : Duty → Time?,           // When duty became Active
+    performed   : Set<(Agent, Action, Asset, Time)>
+}
+
+State ::= Pending | Active | Fulfilled | Violated
+```
+
+**Notes**:
+
+- `State` is a unified lifecycle enum shared by duties, contracts, and subscriptions. The formal semantics tracks duty state during evaluation; contract and subscription state is administrative (not evaluated at request time).
+- Terminal states (`Fulfilled`, `Violated`) are permanent — see §9.4.
+
+**Initial state** Σ₀:
+
+```
+Σ₀ = {
+    clock       = currentSystemTime,
+    state       = λd. Pending,
+    activatedAt = λd. ⊥,
+    performed   = ∅
+}
+```
+
+**State Update Notation**: We use `Σ[f ↦ v]` to denote state update:
+
+```
+Σ[state(d) ↦ Active] =
+    (Σ.clock, Σ.state[d ↦ Active], Σ.activatedAt, Σ.performed)
+
+Σ[state(d) ↦ Active, activatedAt(d) ↦ t] =
+    (Σ.clock, Σ.state[d ↦ Active], Σ.activatedAt[d ↦ t], Σ.performed)
+```
+
+### 4.2 Environment
+
+```
+Env = {
+    agent   : Agent,          // Canonical root: agent
+    action  : Action,
+    asset   : Asset,          // Canonical root: asset
+    context : Context,        // Canonical root: context
+    Σ       : Σ
+}
+```
+
+The three canonical roots (`agent`, `asset`, `context`) are the entry points for `deref` path resolution (see §6.3).
+
+**Environment Construction**: Given a Request `R = (a, x, s, ctx)` and state Σ:
+
+```
+buildEnv(R, Σ) = {
+    agent   = R.agent,
+    action  = R.action,
+    asset   = R.asset,
+    context = R.context,
+    Σ       = Σ
+}
+```
+
+### 4.3 Decision
+
+```
+Decision ::= Permit | Deny | NotApplicable
+```
+
+### 4.4 Evaluation Result
+
+```
+Result = {
+    decision      : Decision,
+    grantorDuties : Set<Duty>,    // Duties on the grantor (data provider)
+    granteeDuties : Set<Duty>,    // Duties on the grantee (data consumer)
+    violations    : Set<Duty>,
+    explanation   : Explanation
+}
+```
+
+---
+
+## 5. Duty Lifecycle
+
+### 5.1 State Diagram
+
+```
+                    condition becomes true
+         ┌─────────────────────────────────────┐
+         │                                     ▼
+     ┌───────┐                            ┌────────┐
+     │Pending│                            │ Active │
+     └───────┘                            └────────┘
+                                           │     │
+                         action performed  │     │  deadline exceeded
+                                           ▼     ▼
+                                    ┌──────────┐ ┌─────────┐
+                                    │Fulfilled │ │Violated │
+                                    └──────────┘ └─────────┘
+```
+
+### 5.2 Transition Rules
+
+**Rule D-ACTIVATE** (Pending → Active):
+
+```
+Σ.state(duty) = Pending
+duty.condition = ⊥ ∨ ⟦duty.condition⟧(Env) = true
+─────────────────────────────────────────────────
+Σ' = Σ[state(duty) ↦ Active, activatedAt(duty) ↦ Σ.clock]
+```
+
+Activation is **condition-driven**: when the duty's condition first evaluates to true (or the duty has no condition), the duty becomes active.
+
+**Rule D-FULFILL** (Active → Fulfilled):
+
+```
+Σ.state(duty) = Active
+performed(duty.subject, duty.action, duty.asset, Σ) = true
+effectiveDeadline(duty, Σ) ≥ Σ.clock  ∨  effectiveDeadline(duty, Σ) = ∞
+────────────────────────────────────────────────────────────────────────
+Σ' = Σ[state(duty) ↦ Fulfilled]
+```
+
+Fulfillment is **event-driven**: when a performed action matches the duty's required action (including narrower actions via `includedIn` subsumption), the duty is fulfilled.
+
+**Rule D-VIOLATE** (Active → Violated):
+
+```
+Σ.state(duty) = Active
+Σ.clock > effectiveDeadline(duty, Σ)
+performed(duty.subject, duty.action, duty.asset, Σ) = false
+────────────────────────────────────────────────────────────
+Σ' = Σ[state(duty) ↦ Violated]
+```
+
+Violation is **time-driven**: when the deadline passes without fulfillment, the duty is violated.
+
+**Algorithmic form** (for implementation):
+
+```
+updateDutyStates(duties, Env, Σ) =
+    foldl(updateOneDuty(Env), Σ, duties)
+
+updateOneDuty(Env)(Σ, d) =
+    case Σ.state(d) of
+        Pending → if d.condition = ⊥ ∨ ⟦d.condition⟧(Env)
+                  then Σ[state(d) ↦ Active, activatedAt(d) ↦ Σ.clock]
+                  else Σ
+        Active  → if performed(d.subject, d.action, d.asset, Σ)
+                  then Σ[state(d) ↦ Fulfilled]
+                  else if Σ.clock > effectiveDeadline(d, Σ)
+                  then Σ[state(d) ↦ Violated]
+                  else Σ
+        _       → Σ  -- Fulfilled/Violated are terminal
+```
+
+### 5.3 Effective Deadline
+
+```
+effectiveDeadline(duty, Σ) =
+    case duty.deadline of
+        ⊥                        → ∞
+        AbsoluteDeadline(t)      → t
+        RelativeDeadline(d)      → Σ.activatedAt(duty) + d
+```
+
+### 5.4 Match Semantics
+
+Action and asset matching support hierarchy subsumption:
+
+```
+x₁ matches x₂ ⟺ x₁ = x₂ ∨ x₁ includedIn⁺ x₂
+s₁ matches s₂ ⟺ s₁ = s₂ ∨ s₁ partOf⁺ s₂
+```
+
+Where `includedIn⁺` and `partOf⁺` are the transitive closures of `odrl:includedIn` and `adalbert:partOf` respectively.
+
+Agent matching supports hierarchy subsumption:
+
+```
+a₁ matches a₂ ⟺ a₁ = a₂ ∨ a₁ memberOf⁺ a₂
+```
+
+Where `memberOf⁺` is the transitive closure of `adalbert:memberOf`.
+
+The subsumption-aware performed check is:
+
+```
+performed(a, x, s, Σ) :=
+    ∃(a', x', s', t) ∈ Σ.performed :
+        a' = a ∧ (x' = x ∨ x' includedIn⁺ x) ∧ s' matches s
+```
+
+`Σ.performed` records exact actions as they occur. `performed()` is the query-time subsumption check used in all fulfillment and violation rules. This is a bounded graph traversal over the `odrl:includedIn` hierarchy.
+
+### 5.5 Recurrence Semantics
+
+A duty with a `recurrence` field defines a recurring obligation. The recurrence value is an RFC 5545 RRULE string (e.g., `FREQ=DAILY;BYHOUR=6;BYMINUTE=0`).
+
+**Instance Generation**:
+
+```
+expand : Recurrence × Time → Set<Time>
+
+expand(RRule(rule), clock) =
+    The set of occurrence times generated by parsing rule as an
+    RFC 5545 RRULE, evaluated relative to clock.
+```
+
+`expand` is a **pure function**: given the same `RRule` value and clock value, it always produces the same set of occurrence times. It is total (an invalid RRULE yields ∅) and deterministic.
+
+**Condition Guard**: If the duty template has a condition, instances are only generated for occurrence times where the condition holds:
+
+```
+occurrences(duty, Σ) =
+    let times = expand(duty.recurrence, Σ.clock)
+    in  { t ∈ times | duty.condition = ⊥ ∨ ⟦duty.condition⟧(Σ.env) }
+```
+
+**Per-Instance Lifecycle**:
+
+Each occurrence time `t` from `occurrences(duty, Σ)` produces an independent duty instance:
+
+```
+instantiate(duty, t) =
+    Duty(subject    = duty.subject,
+         action     = duty.action,
+         asset      = duty.asset,
+         object     = duty.object,
+         condition  = ⊥,
+         deadline   = duty.deadline,
+         recurrence = ⊥)
+    with activationTime = t
+```
+
+Fields carried from the template: `subject`, `action`, `asset`, `object`, `deadline`. Fields dropped: `condition` (the template condition gates instance generation, not individual instances) and `recurrence` (instances are not themselves recurring).
+
+Each instance follows the standard lifecycle (§5.1–§5.2) independently:
+- Activation occurs at the occurrence time `t`
+- The `deadline` defines the per-instance fulfillment window from `t`
+- Fulfillment and violation are tracked per instance
+
+**Interaction with other fields**:
+
+- `recurrence` defines **when** duty instances are generated (scheduling)
+- `deadline` defines **how long** each instance has to be fulfilled (window)
+- Permissions and prohibitions are unaffected by recurrence (recurrence applies only to duties)
+
+---
+
+## 6. Condition Evaluation
+
+### 6.1 Denotational Semantics
+
+```
+⟦_⟧ : Condition × Env → Boolean
+```
+
+**Atomic constraints**:
+
+```
+⟦AtomicConstraint(left, op, right)⟧(Env) =
+    let leftVal = resolve(left, Env)
+    in if leftVal = ⊥ then false
+       else apply(op, leftVal, right)
+```
+
+**Logical connectives** (short-circuit evaluation, left-to-right):
+
+```
+⟦And(c₁, ..., cₙ)⟧(Env) = ⟦c₁⟧(Env) ∧ ... ∧ ⟦cₙ⟧(Env)
+⟦Or(c₁, ..., cₙ)⟧(Env)  = ⟦c₁⟧(Env) ∨ ... ∨ ⟦cₙ⟧(Env)
+⟦Not(c)⟧(Env)           = ¬⟦c⟧(Env)
+```
+
+**Evaluation Order**: `And` evaluates left-to-right, short-circuiting on `false`. `Or` evaluates left-to-right, short-circuiting on `true`. This ensures deterministic evaluation and enables optimizations.
+
+### 6.2 Helper Function Specifications
+
+The condition semantics rely on several helper functions. For a verified kernel, these must be precisely specified.
+
+#### resolve : LeftOperand × Env → Value
+
+The function `resolve(leftOperand, Env)` maps a left operand to a value.
+
+**Resolution Precedence**: Operands are resolved in the following order:
+
+1. **Path-based resolution** — if `op.resolutionPath` is defined, use `deref()`
+2. **Fallback** — return `⊥`
+
+```
+resolve : LeftOperand × Env → Value ∪ {⊥}
+
+resolve(op, Env) =
+    case op of
+        -- Profile-declared operands with resolution path
+        _ | op.resolutionPath ≠ ⊥ →
+            deref(op.resolutionPath, Env)
+
+        -- Dual-typed operands (LeftOperand ∩ RuntimeReference)
+        _ | op ∈ RuntimeRef →
+            resolveRuntime(op, Env)
+
+        -- No resolution path and not a runtime reference
+        _ → ⊥
+```
+
+Where:
+* `op.resolutionPath` — path expression declared on the operand via `adalbert:resolutionPath`
+* `op ∈ RuntimeRef` — the operand is also typed as `adalbert:RuntimeReference` (e.g., `currentDateTime`); resolution delegates to `resolveRuntime` (§6.2). Path-based resolution takes precedence.
+* `⊥` indicates undefined (condition evaluates to `false` when encountered — see §6.1)
+
+**Architectural Principle**: All contextual data access MUST go through declared `odrl:LeftOperand` instances with explicit `adalbert:resolutionPath`, or through dual-typed `RuntimeReference` operands resolved via `resolveRuntime`. This ensures:
+- Type safety (operands can declare expected ranges via `rdfs:range`)
+- Validation (SHACL can verify operand usage at authoring time)
+- Mechanization (clear mapping to formal verification targets)
+- Auditability (all data access points are declared in the profile)
+
+Profiles define domain-specific left operands with resolution paths:
+* `purpose` → `adalbert:resolutionPath "context.purpose"`
+* `classification` → `adalbert:resolutionPath "asset.classification"`
+* `role` → `adalbert:resolutionPath "agent.role"`
+* `environment` → `adalbert:resolutionPath "context.environment"`
+* `timeliness` → `adalbert:resolutionPath "asset.timeliness"`
+* `organization` → `adalbert:resolutionPath "agent.organization"`
+
+#### deref : Path × Env → Value
+
+The function `deref(path, Env)` traverses a path expression to retrieve a value. This is the **primary mechanism for resolving profile-declared operands** via `adalbert:resolutionPath`.
+
+**Path Grammar** (normative):
+
+All path expressions MUST conform to the following grammar:
+
+```
+Path       ::= Root '.' Segment ('.' Segment)*
+Root       ::= 'agent' | 'asset' | 'context'
+Segment    ::= Identifier
+Identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
+```
+
+Constraints:
+- Paths MUST begin with a valid Root
+- Identifiers MUST NOT contain `.`, `/`, `..`, or URL-encoded characters
+- Minimum path depth: 2 segments (root + at least one identifier)
+- Maximum path depth: 10 segments (implementation MAY enforce)
+
+Paths not conforming to this grammar MUST be rejected at parse time, not at evaluation time. This ensures that malformed paths cannot be used to probe for valid segments.
+
+**Canonical Path Roots** (normatively defined):
+
+| Root | Meaning | Example Paths |
+|------|---------|---------------|
+| `agent` | Env.agent (requesting agent) | `agent.role`, `agent.organization`, `agent.costCenter` |
+| `asset` | Env.asset (requested asset) | `asset.classification`, `asset.sensitivity`, `asset.timeliness` |
+| `context` | External request context | `context.purpose`, `context.environment`, `context.jurisdiction` |
+
+```
+deref : Path × Env → Value ∪ {⊥}
+
+deref(path, Env) =
+    let segments = split(path, '.')
+    let root = case head(segments) of
+        "agent"   → Env.agent
+        "asset"   → Env.asset
+        "context" → Env.context
+        _         → ⊥
+    in foldl(navigate, root, tail(segments))
+
+navigate(obj, segment) =
+    case obj of
+        ⊥       → ⊥
+        Record  → obj.segment if segment ∈ fields(obj) else ⊥
+        Map     → obj[segment] if segment ∈ keys(obj) else ⊥
+        _       → ⊥
+```
+
+**Security Requirement: Path Sandboxing** (normative)
+
+Implementations MUST enforce a strict sandbox for `deref` operations. The evaluator MUST reject any path that:
+
+1. Contains directory traversal sequences (e.g., `..`, `/`, `\`)
+2. References roots other than the canonical set (`agent`, `asset`, `context`)
+3. Contains URL-encoded characters or escape sequences
+4. Attempts to access host system variables or environment settings not explicitly mapped to the `Env` object
+
+Rationale: Without these constraints, a malicious path like `context.../../private/key` could escape the policy evaluation sandbox and access host system resources. Path validation MUST occur at parse time to prevent timing-based probing attacks.
+
+**Security Requirements Summary** (normative):
+
+1. **Root validation**: Reject paths not starting with a canonical root (`agent`, `asset`, `context`)
+2. **Grammar validation**: Reject paths containing `..`, `/`, `%`, or other traversal/encoding patterns
+3. **Depth limiting**: MAY reject paths exceeding implementation-defined maximum depth
+4. **Fail-closed**: Return `⊥` (not an error message) for invalid paths to prevent information leakage
+
+These constraints prevent path traversal attacks and unauthorized data access via malformed resolution paths.
+
+#### resolveRuntime : RuntimeRef × Env → Value
+
+Runtime references resolve to values at evaluation time. These are used by `resolve()` for dual-typed left operands (§6.2) — operands typed as both `odrl:LeftOperand` and `adalbert:RuntimeReference` (e.g., `currentDateTime`).
+
+```
+resolveRuntime : RuntimeRef × Env → Value ∪ {⊥}
+
+resolveRuntime(ref, Env) =
+    case ref of
+        currentAgent    → Env.agent
+        currentDateTime → Env.Σ.clock
+        _               → ⊥  -- Unknown runtime reference
+```
+
+#### apply : ComparisonOperator × Value × Value → Boolean
+
+The function `apply(op, left, right)` applies a comparison operator:
+
+```
+apply : ComparisonOperator × Value × Value → Boolean
+
+apply(op, left, right) =
+    case op of
+        eq       → left = right
+        neq      → left ≠ right
+        lt       → left < right
+        lte      → left ≤ right
+        gt       → left > right
+        gte      → left ≥ right
+        isAnyOf  → left ∈ right
+        isNoneOf → left ∉ right
+```
+
+**Type requirements**: Comparison operators `lt`, `lte`, `gt`, `gte` require that both operands are of a comparable type (numbers, dates, durations). If operands are not comparable, the operator returns `false`.
+
+---
+
+## 7. Policy Evaluation
+
+### 7.1 Evaluation Function Signature
+
+```
+Eval : Request × Set<Policy> × Σ → Result
+```
+
+### 7.2 Evaluation Algorithm
+
+```
+Eval(request, policies, Σ) =
+    let Env = buildEnv(request, Σ)
+
+    // Step 0: Find applicable policies
+    let applicable = { p ∈ policies | PolicyApplicable(p, Env) }
+
+    // Step 1: Collect matching norms within applicable policies
+    let prohibitions = { n ∈ p.clauses | p ∈ applicable, n : Prohibition, matches(n, request) }
+    let permissions  = { n ∈ p.clauses | p ∈ applicable, n : Permission, matches(n, request) }
+    let allDuties    = { n ∈ p.clauses | p ∈ applicable, n : Duty, matches(n, request) }
+
+    // Step 2: Partition duties by bearer (bilateral)
+    let grantorDuties = { d ∈ allDuties | d.subject = policy(d).grantor }
+    let granteeDuties = { d ∈ allDuties | d.subject = policy(d).grantee }
+
+    // Step 3: Update duty states
+    let Σ' = updateDutyStates(allDuties, Env, Σ)
+
+    // Step 4: Check for active prohibitions (prohibition overrides)
+    if ∃p ∈ prohibitions. NormActive(p, Env) then
+        return {decision: Deny, ...}
+
+    // Step 5: Check for granting privilege
+    if ∄p ∈ permissions. NormActive(p, Env) then
+        return {decision: NotApplicable, ...}
+
+    // Step 6: Check for violations
+    let violated = { d ∈ allDuties | Σ'.state(d) = Violated }
+    if violated ≠ ∅ then
+        return {decision: Deny, violations: violated, ...}
+
+    // Step 7: Collect active duties for both parties
+    let activeGrantor = { d ∈ grantorDuties | Σ'.state(d) = Active }
+    let activeGrantee = { d ∈ granteeDuties | Σ'.state(d) = Active }
+
+    return {
+        decision: Permit,
+        grantorDuties: activeGrantor,
+        granteeDuties: activeGrantee,
+        violations: ∅
+    }
+```
+
+### 7.3 Policy Applicability
+
+```
+PolicyApplicable(p, Env) =
+    // Target matches (if specified)
+    (p.target = ⊥ ∨ Env.asset matches p.target) ∧
+    // Policy condition satisfied
+    (p.condition = ⊥ ∨ ⟦p.condition⟧(Env))
+```
+
+For Agreements (including Subscriptions), the agent must be a party:
+
+```
+PolicyApplicable(Agreement(grantor, grantee, ...), Env) =
+    ... ∧ (Env.agent matches grantee ∨ Env.agent matches grantor)
+```
+
+### 7.4 Norm Activation
+
+A norm within a policy is active when both the policy is applicable and the norm's own conditions hold:
+
+```
+NormActive(norm, Env) =
+    (norm.subject = ⊥ ∨ norm.subject = Env.agent ∨ norm.subject = *
+     ∨ Env.agent memberOf⁺ norm.subject) ∧
+    norm.action matches Env.action ∧
+    (norm.asset = ⊥ ∨ norm.asset matches Env.asset) ∧
+    (norm.condition = ⊥ ∨ ⟦norm.condition⟧(Env))
+```
+
+Where `⊥` indicates no assignee specified (rule applies to any requesting agent), `*` is the wildcard agent, and `memberOf⁺` is transitive party membership. In standard ODRL usage, Set and Offer policies omit `odrl:assignee` on rules that apply to any requesting agent; `adalbert:currentAgent` is reserved for constraint comparisons (identity binding), not for assignee position.
+
+---
+
+## 8. Conflict Resolution
+
+### 8.1 Strategy: Prohibition Overrides
+
+Adalbert uses a fixed conflict resolution strategy:
+
+```
+Prohibition > Permission
+```
+
+If both a prohibition and permission match, the prohibition wins. This strategy is not configurable in Adalbert (RL2 offers configurable strategies).
+
+### 8.2 Algorithm
+
+```
+resolveDecision(prohibitions, permissions) =
+    if ∃p ∈ prohibitions. active(p) then
+        Deny
+    else if ∃p ∈ permissions. active(p) then
+        Permit
+    else
+        NotApplicable
+```
+
+No specificity ordering within norm types. All matching norms contribute.
+
+**Note**: `NotApplicable` (no matching rule) is distinct from `Deny` (explicit prohibition). This allows policy composition where a higher-level policy can provide defaults.
+
+---
+
+## 9. Correctness Properties
+
+**Note on recurrence**: All four theorems below hold in the presence of `recurrence`. The `expand` function is total and deterministic (§5.5), each generated instance follows the standard lifecycle independently, and recurrence applies only to duties — permissions and prohibitions are unaffected.
+
+### 9.1 Totality
+
+**Theorem**: For all well-formed inputs, `Eval` terminates with a defined result.
+
+```
+∀ request, policies, Σ.
+    WellFormed(request) ∧ WellFormed(policies) ∧ WellFormed(Σ)
+    ⟹ ∃ result. Eval(request, policies, Σ) = result ∧ result ≠ ⊥
+```
+
+### 9.2 Determinism
+
+**Theorem**: Evaluation is deterministic.
+
+```
+∀ request, policies, Σ.
+    Eval(request, policies, Σ) = r₁ ∧ Eval(request, policies, Σ) = r₂
+    ⟹ r₁ = r₂
+```
+
+### 9.3 Prohibition Monotonicity
+
+**Theorem**: Adding policies cannot remove prohibitions.
+
+```
+∀ request, P, P', Σ.
+    P ⊆ P' ∧ Eval(request, P, Σ).decision = Deny
+    ⟹ Eval(request, P', Σ).decision = Deny
+```
+
+### 9.4 Duty Lifecycle Invariants
+
+**Theorem**: Terminal states are permanent.
+
+```
+∀ d, Σ, Σ'.
+    Σ → Σ' ∧ Σ.state(d) ∈ {Fulfilled, Violated}
+    ⟹ Σ'.state(d) = Σ.state(d)
+```
+
+**Theorem**: Duty-state consistency (no duty is in two states simultaneously).
+
+```
+∀ d, Σ.
+    WellFormed(Σ) ⟹ |{ s | Σ.state(d) = s }| = 1
+```
+
+### 9.5 Path Resolution Safety
+
+**Theorem**: Path resolution is sandboxed.
+
+```
+∀ path, Env.
+    ¬conformsToGrammar(path) ⟹ deref(path, Env) = ⊥
+```
+
+**Theorem**: Path resolution cannot escape canonical roots.
+
+```
+∀ path, Env.
+    deref(path, Env) ≠ ⊥ ⟹ head(split(path, '.')) ∈ {"agent", "asset", "context"}
+```
+
+**Theorem**: Path resolution is total and fail-closed.
+
+```
+∀ path, Env.
+    conformsToGrammar(path) ⟹ deref(path, Env) ∈ Value ∪ {⊥}
+```
+
+---
+
+## 10. Complexity and Constraints
+
+*This section is non-normative.*
+
+Adalbert evaluation is designed to be **polynomial-time** and **total** under the following constraints.
+
+### 10.1 Structural Constraints
+
+1. **Finite policy universe**: The set of policies is finite
+2. **Bounded condition nesting**: Conditions have bounded depth (recommended ≤ 20)
+3. **Acyclic conditions**: No self-referential condition definitions
+4. **Finite Σ**: State contains finite sets (performed actions, duty states)
+5. **No recursive policy references**: Policies cannot invoke evaluation of other policies
+
+### 10.2 Path Resolution Constraints
+
+6. **Bounded path depth**: Maximum 10 segments (enforced by grammar)
+7. **No joins**: Path resolution is single-threaded navigation, not graph pattern matching
+8. **Deterministic navigation**: Each segment resolves to exactly one value or `⊥`
+
+### 10.3 Complexity Analysis
+
+Given these constraints:
+
+| Operation | Complexity |
+|-----------|------------|
+| Path resolution (`deref`) | O(d) where d = path depth |
+| Condition evaluation | O(n × d) where n = condition tree size |
+| Norm matching | O(\|P\| × m) where m = max clauses per policy |
+| Hierarchy traversal (`matches`) | O(h) where h = hierarchy depth |
+| Conflict resolution | O(k) where k = matched norms |
+| **Total `Eval`** | **O(\|P\| × m × n × d × h)** — polynomial |
+
+### 10.4 Totality Guarantees
+
+Under these constraints, `Eval` is **total**: it terminates for all well-formed inputs. The function never:
+
+- Loops infinitely (no recursive evaluation)
+- Blocks on external resources (resolution is synchronous or fails to `⊥`)
+- Diverges due to condition structure (bounded, acyclic)
+
+---
+
+## 11. Profile Extension Points
+
+### 11.1 Left Operands
+
+Profiles attach Adalbert resolution paths to operands. Standard ODRL operands (like `odrl:purpose`) are extended in-place; domain-specific operands are declared as new `odrl:LeftOperand` instances:
+
+```turtle
+# Extend an existing ODRL operand with a resolution path
+odrl:purpose adalbert:resolutionPath "context.purpose" .
+
+# Declare a new domain-specific operand
+adalbert-due:timeliness a odrl:LeftOperand ;
+    adalbert:resolutionPath "asset.timeliness" .
+```
+
+The `resolutionPath` value must conform to the path grammar defined in §6.2 (`deref`). SHACL validation enforces that all resolution paths start with a canonical root:
+
+```turtle
+adalbertsh:LeftOperandShape a sh:NodeShape ;
+    sh:targetClass odrl:LeftOperand ;
+    sh:property [
+        sh:path adalbert:resolutionPath ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:pattern "^(agent|asset|context)\\." ;
+        sh:message "resolutionPath must start with agent., asset., or context."
+    ] .
+```
+
+### 11.2 Action Hierarchies
+
+```turtle
+odrl:display a odrl:Action ;
+    odrl:includedIn odrl:use .
+```
+
+Action subsumption is defined by the transitive closure of `odrl:includedIn`:
+
+```
+x' ⊑ x  :=  reachable(x', odrl:includedIn, x)
+```
+
+Evaluators MUST support transitive traversal of `odrl:includedIn`.
+
+### 11.3 Asset Hierarchies
+
+```turtle
+ex:customerTable a odrl:Asset ;
+    adalbert:partOf ex:customerSchema .
+```
+
+Asset subsumption is defined by the transitive closure of `adalbert:partOf`:
+
+```
+s' ⊑ s  :=  reachable(s', adalbert:partOf, s)
+```
+
+### 11.4 Agent Hierarchies
+
+```turtle
+ex:analyst adalbert:memberOf ex:analyticsTeam .
+ex:analyticsTeam adalbert:memberOf ex:dataDivision .
+```
+
+Agent subsumption is defined by the transitive closure of `adalbert:memberOf`:
+
+```
+a' ⊑ a  :=  reachable(a', adalbert:memberOf, a)
+```
+
+Policy on `ex:dataDivision` applies to `ex:analyst` via transitivity.
+
+---
+
+## 12. Bilateral Agreement Semantics
+
+### 12.1 Motivation
+
+ODRL 2.2 evaluates agreements from the assignee's perspective only. This prevents modeling provider obligations (SLAs, data quality commitments).
+
+Adalbert fixes this: evaluation returns duties for **both** parties.
+
+### 12.2 Formal Definition
+
+For an Agreement (or Subscription), duties are partitioned by bearer:
+
+```
+grantorDuties(agreement) = { d ∈ agreement.clauses | d : Duty ∧ d.subject = agreement.grantor }
+granteeDuties(agreement) = { d ∈ agreement.clauses | d : Duty ∧ d.subject = agreement.grantee }
+```
+
+Both sets are included in the evaluation result, with independent lifecycle tracking.
+
+### 12.3 Example
+
+```turtle
+@prefix ex:   <http://example.org/> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:agreement a odrl:Agreement ;
+    odrl:assigner ex:dataTeam ;
+    odrl:assignee ex:analyticsTeam ;
+    odrl:target ex:marketData ;
+
+    # Assignee permission (target inherited from policy)
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee ex:analyticsTeam ;
+        odrl:action odrl:display
+    ] ;
+
+    # Assignee duty (consumer reports to provider)
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:analyticsTeam ;
+        adalbert:object ex:dataTeam ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:usageStats ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # Assigner duty (provider notifies consumer)
+    odrl:obligation [
+        a odrl:Duty ;
+        adalbert:subject ex:dataTeam ;
+        adalbert:object ex:analyticsTeam ;
+        odrl:action adalbert-due:notify ;
+        odrl:target ex:schemaChanges ;
+        adalbert:deadline "P7D"^^xsd:duration
+    ] .
+```
+
+Evaluation returns:
+- `granteeDuties`: report usage within 30 days
+- `grantorDuties`: notify of schema changes within 7 days
+
+---
+
+## 13. Mechanization
+
+*This section is non-normative.*
+
+Adalbert's semantics are explicitly designed for mechanization. The abstract syntax maps to algebraic datatypes, and the operational rules are syntax-directed.
+
+### 13.1 Target Platforms
+
+| Platform | Strengths | Status |
+|----------|-----------|--------|
+| **Dafny** | Algebraic types, Z3 backend, compiles to Go/Java/C# | Primary target |
+| **Why3** | Multi-prover backend, mature specification language | Alternative |
+
+### 13.2 Dafny Sketch
+
+```dafny
+datatype State = Pending | Active | Fulfilled | Violated
+
+datatype Condition =
+  | AtomicConstraint(op: LeftOperand, cmp: Operator, val: Value)
+  | And(left: Condition, right: Condition)
+  | Or(left: Condition, right: Condition)
+  | Not(inner: Condition)
+
+function Deref(path: string, env: Env): Option<Value>
+  requires ValidPath(path)
+  ensures Deref(path, env).None? ==> !PathResolvable(path, env)
+{
+  var segments := Split(path, '.');
+  var root := match segments[0]
+    case "agent" => Some(env.agent)
+    case "asset" => Some(env.asset)
+    case "context" => Some(env.context)
+    case _ => None;
+  FoldNavigate(root, segments[1..])
+}
+
+function Resolve(op: LeftOperand, env: Env): Option<Value>
+  requires ValidEnv(env)
+{
+  if op.resolutionPath.Some? then Deref(op.resolutionPath.value, env)
+  else None
+}
+
+function EvalCondition(c: Condition, env: Env): bool
+  requires ValidEnv(env)
+  ensures EvalCondition(c, env) ==> ConditionSatisfied(c, env)
+{
+  match c
+    case AtomicConstraint(op, cmp, val) =>
+      var leftVal := Resolve(op, env);
+      if leftVal.None? then false
+      else Apply(cmp, leftVal.value, val)
+    case And(l, r) => EvalCondition(l, env) && EvalCondition(r, env)
+    case Or(l, r) => EvalCondition(l, env) || EvalCondition(r, env)
+    case Not(inner) => !EvalCondition(inner, env)
+}
+```
+
+Transition rules are expressed as Dafny lemmas with pre/post-conditions verified by Z3.
+
+### 13.3 Proof Obligations
+
+The following properties should be proved for a verified implementation:
+
+1. **(S1) Determinism**: Given Σ, request, policies, evaluation produces a unique result
+2. **(S2) Totality**: `Eval` terminates for all well-formed inputs
+3. **(S3) Duty-state consistency**: No duty can be simultaneously in two states
+4. **(S4) Terminal permanence**: Fulfilled/Violated states never revert
+5. **(S5) Path safety**: `deref` returns `⊥` for any non-conforming path
+6. **(S6) Prohibition monotonicity**: Adding policies cannot remove prohibitions
+
+---
+
+## 14. References
+
+- [ODRL Information Model 2.2](https://www.w3.org/TR/odrl-model/)
+- [ODRL Vocabulary 2.2](https://www.w3.org/TR/odrl-vocab/)
+- [RL2 Formal Semantics](../../RL2/RL2_Semantics.md)
+- Adalbert Core Ontology — `ontology/adalbert-core.ttl`
+- Adalbert SHACL Shapes — `ontology/adalbert-shacl.ttl`
+- Adalbert DUE Profile — `profiles/adalbert-due.ttl`

--- a/adalbert-contracts/docs/SPECIFICATION.md
+++ b/adalbert-contracts/docs/SPECIFICATION.md
@@ -1,0 +1,512 @@
+# Adalbert Technical Specification
+
+RDF/OWL vocabulary reference for the Adalbert ODRL 2.2 profile.
+
+---
+
+## 1. Introduction
+
+This document is a vocabulary reference for implementers. It defines every class and property that Adalbert adds to ODRL 2.2, their types, domains, ranges, and cardinalities.
+
+**Scope**: This document covers the RDF/OWL vocabulary. For formal evaluation semantics, see [Adalbert_Semantics.md](Adalbert_Semantics.md). For practical authoring guidance, see [contracts-guide.md](contracts-guide.md) and [policy-writers-guide.md](policy-writers-guide.md).
+
+**Source files**:
+
+| File | Contents |
+|------|----------|
+| `ontology/adalbert-core.ttl` | Core ontology (classes, properties) |
+| `ontology/adalbert-shacl.ttl` | SHACL validation shapes |
+| `profiles/adalbert-due.ttl` | DUE vocabulary (operands, actions, concept values) |
+| `config/namespaces.ttl` | Authoritative namespace registry |
+
+---
+
+## 2. Namespace Declarations
+
+```turtle
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbertsh:   <https://vocabulary.bigbank/adalbert/shapes/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix rdf:          <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:         <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:          <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos:         <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms:      <http://purl.org/dc/terms/> .
+@prefix prov:         <http://www.w3.org/ns/prov#> .
+@prefix sh:           <http://www.w3.org/ns/shacl#> .
+```
+
+---
+
+## 3. Class Definitions
+
+### 3.1 adalbert:State
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:Class` |
+| **Label** | State |
+| **Definition** | Unified lifecycle state for duties and contracts |
+| **Enumeration** | `adalbert:Pending`, `adalbert:Active`, `adalbert:Fulfilled`, `adalbert:Violated` |
+
+**Individuals**:
+
+| Individual | Label | Definition |
+|------------|-------|------------|
+| `adalbert:Pending` | Pending | Condition not yet satisfied; not yet in force |
+| `adalbert:Active` | Active | Condition satisfied, action required; in force |
+| `adalbert:Fulfilled` | Fulfilled | Action performed; obligations complete |
+| `adalbert:Violated` | Violated | Deadline passed without performance; breached |
+
+**State transitions** (see [Adalbert_Semantics.md](Adalbert_Semantics.md) for formal definition):
+
+```
+Pending -> Active    (condition becomes true)
+Active  -> Fulfilled (action performed)
+Active  -> Violated  (deadline passed without performance)
+```
+
+### 3.2 adalbert:DataContract
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:Class` |
+| **Superclass** | `odrl:Offer` |
+| **Label** | Data Contract |
+| **Definition** | Policy offer defining data access terms |
+
+**Required properties**:
+
+| Property | Source | Cardinality |
+|----------|--------|-------------|
+| `odrl:profile` | ODRL | 1..* (must include Adalbert profile URI) |
+| `odrl:assigner` | ODRL | 1 |
+
+**Recommended properties**:
+
+| Property | Source | Cardinality |
+|----------|--------|-------------|
+| `odrl:target` | ODRL | 1..* |
+| `adalbert:state` | Adalbert | 0..1 |
+| `adalbert:effectiveDate` | Adalbert | 0..1 |
+| `adalbert:expirationDate` | Adalbert | 0..1 |
+
+**Rule properties** (from ODRL):
+
+| Property | Contains |
+|----------|----------|
+| `odrl:obligation` | Provider duties (with `adalbert:subject`), consumer duties (without subject in Offer) |
+| `odrl:permission` | Consumer permissions |
+| `odrl:prohibition` | Restrictions |
+
+**Example**:
+
+```turtle
+ex:contract a adalbert:DataContract ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:dataTeam ;
+    odrl:target ex:marketPrices ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime .
+```
+
+### 3.3 adalbert:Subscription
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:Class` |
+| **Superclass** | `odrl:Agreement` |
+| **Label** | Subscription |
+| **Definition** | Activated data contract binding provider and consumer |
+
+**Required properties**:
+
+| Property | Source | Cardinality |
+|----------|--------|-------------|
+| `odrl:profile` | ODRL | 1..* |
+| `odrl:assigner` | ODRL | 1 |
+| `odrl:assignee` | ODRL | 1 |
+| `adalbert:subscribesTo` | Adalbert | 1 |
+
+**Recommended properties**:
+
+| Property | Source | Cardinality |
+|----------|--------|-------------|
+| `adalbert:state` | Adalbert | 0..1 |
+| `adalbert:effectiveDate` | Adalbert | 0..1 |
+| `adalbert:expirationDate` | Adalbert | 0..1 |
+
+**Example**:
+
+```turtle
+ex:subscription a adalbert:Subscription ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo ex:contract ;
+    odrl:assigner ex:dataTeam ;
+    odrl:assignee ex:analyticsTeam ;
+    adalbert:effectiveDate "2026-01-15T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime .
+```
+
+### 3.4 adalbert:RuntimeReference
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:Class` |
+| **Label** | Runtime Reference |
+| **Definition** | Value resolved at evaluation time |
+
+**Individuals**:
+
+| Individual | Types | Definition |
+|------------|-------|------------|
+| `adalbert:currentAgent` | `adalbert:RuntimeReference`, `odrl:Party` | The requesting agent (resolved at evaluation time) |
+| `adalbert:currentDateTime` | `odrl:LeftOperand`, `adalbert:RuntimeReference` | Evaluation timestamp (mapped to `odrl:dateTime`) |
+
+---
+
+## 4. Property Definitions
+
+### 4.1 adalbert:state
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty` |
+| **Domain** | `odrl:Duty` | `adalbert:DataContract` | `adalbert:Subscription` |
+| **Range** | `adalbert:State` |
+| **Cardinality** | 0..1 |
+| **Definition** | Current lifecycle state |
+
+### 4.2 adalbert:deadline
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:DatatypeProperty` |
+| **Domain** | `odrl:Duty` |
+| **Range** | `xsd:dateTime` | `xsd:duration` (enforced by SHACL) |
+| **Cardinality** | 0..1 |
+| **Definition** | Time constraint for duty fulfillment |
+
+Two forms:
+
+| Form | Datatype | Meaning | Example |
+|------|----------|---------|---------|
+| Absolute | `xsd:dateTime` | Fixed deadline | `"2026-12-31T23:59:59Z"^^xsd:dateTime` |
+| Relative | `xsd:duration` | Offset from activation | `"P30D"^^xsd:duration` |
+
+### 4.3 adalbert:recurrence
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:DatatypeProperty` |
+| **Domain** | `odrl:Duty` |
+| **Range** | `xsd:string` |
+| **Cardinality** | 0..1 |
+| **Pattern** | `^FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)` |
+| **Definition** | RFC 5545 RRULE defining when duty instances are generated |
+
+Each generated instance follows the standard duty lifecycle independently (Pending -> Active -> Fulfilled/Violated). The `deadline` property defines the per-instance fulfillment window. Any iCal-compliant library can parse the value.
+
+### 4.4 adalbert:subscribesTo
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty` |
+| **Domain** | `adalbert:Subscription` |
+| **Range** | `adalbert:DataContract` |
+| **Cardinality** | 1 |
+| **Definition** | The contract this subscription activates |
+
+### 4.5 adalbert:effectiveDate
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:DatatypeProperty` |
+| **Domain** | `adalbert:DataContract` | `adalbert:Subscription` |
+| **Range** | `xsd:dateTime` |
+| **Cardinality** | 0..1 |
+| **Definition** | When the contract/subscription becomes effective |
+
+### 4.6 adalbert:expirationDate
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:DatatypeProperty` |
+| **Domain** | `adalbert:DataContract` | `adalbert:Subscription` |
+| **Range** | `xsd:dateTime` |
+| **Cardinality** | 0..1 |
+| **Definition** | When the contract/subscription expires |
+
+### 4.7 adalbert:partOf
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty`, `owl:TransitiveProperty` |
+| **SubPropertyOf** | `odrl:partOf` |
+| **Domain** | `odrl:Asset` |
+| **Range** | `odrl:Asset` |
+| **Cardinality** | 0..* |
+| **Definition** | Asset contained in a larger asset |
+
+Transitive: if table `partOf` schema and schema `partOf` database, then table `partOf` database. Declared `rdfs:subPropertyOf odrl:partOf` so ODRL processors with RDFS reasoning can interpret Adalbert asset hierarchies.
+
+### 4.8 adalbert:memberOf
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty`, `owl:TransitiveProperty` |
+| **SubPropertyOf** | `odrl:partOf` |
+| **Domain** | `odrl:Party` |
+| **Range** | `odrl:Party` |
+| **Cardinality** | 0..* |
+| **Definition** | Party member of a group or organization |
+
+Transitive: if person `memberOf` team and team `memberOf` division, then person `memberOf` division. Declared `rdfs:subPropertyOf odrl:partOf` so ODRL processors with RDFS reasoning can interpret Adalbert party hierarchies.
+
+### 4.9 adalbert:resolutionPath
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:DatatypeProperty` |
+| **Domain** | `odrl:LeftOperand` |
+| **Range** | `xsd:string` |
+| **Cardinality** | 0..1 |
+| **Pattern** | `^(agent|asset|context)\.` |
+| **Definition** | Dot-separated path from canonical root to value |
+
+Canonical roots:
+
+| Root | Meaning | Examples |
+|------|---------|----------|
+| `agent` | Requesting agent | `agent.role`, `agent.organization`, `agent.costCenter` |
+| `asset` | Target asset | `asset.classification`, `asset.market`, `asset.residency` |
+| `context` | Request context | `context.purpose`, `context.environment`, `context.legalBasis` |
+
+### 4.10 adalbert:not
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty` |
+| **Domain** | `odrl:LogicalConstraint` |
+| **Range** | `odrl:Constraint` | `odrl:LogicalConstraint` |
+| **Cardinality** | 0..1 (exactly one of `odrl:and`, `odrl:or`, `adalbert:not` per LogicalConstraint) |
+| **Definition** | Logical negation on a constraint |
+
+ODRL defines `odrl:and` and `odrl:or` but lacks negation. Adalbert adds `adalbert:not` following the same pattern.
+
+### 4.11 adalbert:subject
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty` |
+| **SubPropertyOf** | `odrl:assignee` |
+| **Domain** | `odrl:Duty` |
+| **Range** | `odrl:Party` |
+| **Cardinality** | 0..1 |
+| **Definition** | Party bearing the duty (must perform the action) |
+
+The duty bearer. Replaces `odrl:assignee` on duties to avoid role overloading — in a bilateral agreement, the data provider is `odrl:assigner` at the policy level but would also need to be `odrl:assignee` on their own delivery duty. `adalbert:subject` removes this confusion. Bridges to ODRL via `rdfs:subPropertyOf odrl:assignee` (itself a sub-property of `odrl:function`), so ODRL processors with RDFS reasoning can infer `odrl:assignee` from `adalbert:subject`. Aligns with `md:subject` (W3C Market Data) and `rl2:subject`.
+
+### 4.12 adalbert:object
+
+| Property | Value |
+|----------|-------|
+| **Type** | `owl:ObjectProperty` |
+| **SubPropertyOf** | `odrl:function` |
+| **Domain** | `odrl:Duty` |
+| **Range** | `odrl:Party` |
+| **Cardinality** | 0..1 |
+| **Definition** | Party affected by the duty action |
+
+The party affected by or receiving the result of the duty action (e.g., who is notified, who receives the report). Bridges to ODRL via `rdfs:subPropertyOf odrl:function`. Aligns with `md:object` (W3C Market Data) and `rl2:counterparty`.
+
+**ODRL Common Vocabulary alternatives**: ODRL defines action-specific party functions that may be more semantically precise than `adalbert:object` in certain cases:
+
+| ODRL Function | Use when... | Example |
+|---|---|---|
+| `odrl:informedParty` | The duty is to inform/notify a party | Schema change notification |
+| `odrl:compensatedParty` | The duty involves compensation | License fee payment |
+| `odrl:trackedParty` | The duty involves tracking/monitoring | Usage tracking |
+| `odrl:consentingParty` | The duty requires obtaining consent | Data processing consent |
+
+Use `adalbert:object` as the generic alternative when no specific ODRL function fits, or when you prefer consistency across duty types. All are sub-properties of `odrl:function`.
+
+---
+
+## 5. DUE Vocabulary Summary
+
+The DUE profile (`profiles/adalbert-due.ttl`) provides the complete data governance vocabulary.
+
+### 5.1 Operand Categories
+
+| Category | Operands | Resolution Root |
+|----------|----------|-----------------|
+| **Purpose** | `odrl:purpose` | `context.purpose` |
+| **Classification** | `adalbert-due:classification`, `adalbert-due:sensitivity` | `asset.*` |
+| **Asset metadata** | `adalbert-due:assetClass`, `adalbert-due:market`, `adalbert-due:isBenchmark` | `asset.*` |
+| **Jurisdiction** | `adalbert-due:jurisdiction`, `adalbert-due:residency` | `context.*`, `asset.*` |
+| **Temporal** | `adalbert-due:retentionPeriod`, `adalbert-due:expiry` | `asset.*` |
+| **Processing** | `adalbert-due:processingMode` | `context.processingMode` |
+| **Audit** | `adalbert-due:auditRequired` | `asset.auditRequired` |
+| **Identity** | `adalbert-due:role`, `adalbert-due:organization`, `adalbert-due:costCenter`, `adalbert-due:project`, `adalbert-due:recipientType` | `agent.*`, `context.*` |
+| **Environment** | `adalbert-due:environment`, `adalbert-due:network` | `context.*` |
+| **Timeliness** | `adalbert-due:timeliness`, `adalbert-due:delayMinutes` | `asset.*` |
+| **Legal basis** | `adalbert-due:legalBasis`, `adalbert-due:consentId` | `context.*` |
+| **Access pattern** | `adalbert-due:accessPattern`, `adalbert-due:volumeLimit`, `adalbert-due:rateLimit` | `context.*` |
+| **Derivation** | `adalbert-due:derivationType` | `context.derivationType` |
+
+### 5.2 Actions
+
+**ODRL Common Vocabulary** (used directly):
+
+| Action | Definition | Hierarchy |
+|--------|------------|-----------|
+| `odrl:use` | General use | Top of hierarchy |
+| `odrl:read` | Read/view | `includedIn odrl:use` |
+| `odrl:display` | Display to users | `includedIn odrl:use` |
+| `odrl:distribute` | Distribute to third parties | `includedIn odrl:use` |
+| `odrl:delete` | Delete the asset | `includedIn odrl:use` |
+| `odrl:modify` | Modify the asset | `includedIn odrl:use` |
+| `odrl:aggregate` | Aggregate with other data | `includedIn odrl:use` |
+| `odrl:anonymize` | Remove identifying info | `includedIn odrl:use` |
+| `odrl:derive` | Create derived data | `includedIn odrl:use` |
+
+**DUE-specific actions**:
+
+| Action | Definition | Hierarchy |
+|--------|------------|-----------|
+| `adalbert-due:nonDisplay` | Automated/programmatic use | `includedIn odrl:use` |
+| `adalbert-due:conformTo` | Conform to a schema or spec | No parent (duty-only governance action) |
+| `adalbert-due:log` | Log access to the asset | `includedIn odrl:inform` |
+| `adalbert-due:notify` | Notify relevant parties | `includedIn odrl:inform` |
+| `adalbert-due:report` | Submit usage reports | `includedIn odrl:inform` |
+| `adalbert-due:deliver` | Deliver data to consumer | `includedIn odrl:distribute` |
+| `adalbert-due:calculateIndex` | Use for index calculation | `includedIn odrl:derive` |
+| `adalbert-due:algorithmicTrading` | Use for automated trading | `includedIn adalbert-due:nonDisplay` |
+| `adalbert-due:query` | Query/select data | `includedIn odrl:read` |
+| `adalbert-due:export` | Export data outside system | `includedIn odrl:distribute` |
+| `adalbert-due:copy` | Copy data to another location | `includedIn odrl:reproduce` |
+| `adalbert-due:link` | Link/join with other datasets | `includedIn odrl:aggregate` |
+| `adalbert-due:profile` | Create profiles from data | `includedIn odrl:derive` |
+
+### 5.3 Concept Values
+
+Key SKOS concept values defined by DUE:
+
+| Category | Values |
+|----------|--------|
+| Purpose | `analytics`, `research`, `compliance`, `operations` |
+| Classification | `public`, `internal`, `confidential`, `restricted` |
+| Sensitivity | `pii` (PII), `mnpi` (MNPI), `phi` (PHI) |
+| Processing mode | `human`, `automated`, `modelTraining`, `inference` |
+| Environment | `production`, `staging`, `development`, `sandbox` |
+| Network | `internalNetwork`, `externalNetwork`, `cloudNetwork` |
+| Timeliness | `realtime`, `nearRealtime`, `delayed`, `endOfDay`, `historical` |
+| Legal basis | `consent`, `contract`, `legalObligation`, `vitalInterest`, `publicTask`, `legitimateInterest` |
+| Access pattern | `batch`, `streaming`, `interactive`, `api` |
+| Derivation type | `commingled`, `nonSubstitutive`, `newProduct` |
+
+---
+
+## 6. SHACL Constraints Summary
+
+Shapes are defined in `ontology/adalbert-shacl.ttl`. Key constraints:
+
+### Policy-level shapes
+
+| Shape | Target | Key Constraints |
+|-------|--------|-----------------|
+| `adalbertsh:PolicyShape` | `odrl:Policy` | Must declare `odrl:profile` (for engines with RDFS inference) |
+| `adalbertsh:SetShape` | `odrl:Set` | Must declare `odrl:profile`; at least one `odrl:target`; at least one clause |
+| `adalbertsh:OfferShape` | `odrl:Offer` | Must declare `odrl:profile`; exactly one `odrl:assigner`; at least one clause |
+| `adalbertsh:AgreementShape` | `odrl:Agreement` | Must declare `odrl:profile`; exactly one `odrl:assigner` and one `odrl:assignee`; at least one clause |
+
+### Rule-level shapes
+
+| Shape | Target | Key Constraints |
+|-------|--------|-----------------|
+| `adalbertsh:PermissionShape` | `odrl:Permission` | Exactly one `odrl:action`; at most one `odrl:target` (inherited from policy if absent) |
+| `adalbertsh:ProhibitionShape` | `odrl:Prohibition` | Exactly one `odrl:action`; at most one `odrl:target` (inherited from policy if absent) |
+| `adalbertsh:DutyShape` | `odrl:Duty` | Exactly one `odrl:action`; `subject` 0..1; `object` 0..1; `deadline` 0..1 (dateTime/duration); `recurrence` 0..1 (RRULE pattern); `state` 0..1 |
+
+### Constraint-level shapes
+
+| Shape | Target | Key Constraints |
+|-------|--------|-----------------|
+| `adalbertsh:ConstraintShape` | `odrl:Constraint` | Exactly one `leftOperand`, `operator`, and at least one `rightOperand` |
+| `adalbertsh:LogicalConstraintShape` | `odrl:LogicalConstraint` | Exactly one of: `odrl:and`, `odrl:or`, or `adalbert:not` |
+
+### Contract-level shapes
+
+| Shape | Target | Key Constraints |
+|-------|--------|-----------------|
+| `adalbertsh:DataContractShape` | `adalbert:DataContract` | Must declare `odrl:profile`; exactly one `odrl:assigner`; at least one clause; `state` 0..1; effective/expiration dates 0..1 |
+| `adalbertsh:SubscriptionShape` | `adalbert:Subscription` | Must declare `odrl:profile`; exactly one `adalbert:subscribesTo` (must be `adalbert:DataContract`); at least one clause; `state` 0..1; effective/expiration dates 0..1 |
+
+### Operand shapes
+
+| Shape | Target | Key Constraints |
+|-------|--------|-----------------|
+| `adalbertsh:LeftOperandShape` | `odrl:LeftOperand` | `resolutionPath` 0..1; must start with `agent.`, `asset.`, or `context.` |
+| `adalbertsh:DUEOperandShape` | All 26 DUE operands | Exactly one `resolutionPath` (pattern: `agent.\|asset.\|context.`) |
+
+### Rejection shapes
+
+| Shape | Rejects | Message |
+|-------|---------|---------|
+| `adalbertsh:RejectXoneShape` | `odrl:xone` | Not supported in Adalbert |
+| `adalbertsh:RejectRemedyShape` | `odrl:remedy` | Deferred to RL2 |
+| `adalbertsh:RejectConsequenceShape` | `odrl:consequence` | Deferred to RL2 |
+| `adalbertsh:RejectTicketShape` | `odrl:Ticket` | Not supported |
+| `adalbertsh:RejectRequestShape` | `odrl:Request` | Not supported |
+| `adalbertsh:RejectAssetCollectionShape` | `odrl:AssetCollection` | Use `adalbert:partOf` instead |
+| `adalbertsh:RejectPartyCollectionShape` | `odrl:PartyCollection` | Use `adalbert:memberOf` instead |
+| `adalbertsh:RejectInheritAllowedShape` | `odrl:inheritAllowed` | Not supported |
+| `adalbertsh:RejectInheritFromShape` | `odrl:inheritFrom` | Not supported |
+
+---
+
+## 7. Property Usage Matrix
+
+Which Adalbert properties are valid on which classes:
+
+| Property | Duty | DataContract | Subscription | LeftOperand | LogicalConstraint | Asset | Party |
+|----------|------|-------------|-------------|-------------|-------------------|-------|-------|
+| `adalbert:state` | Yes | Yes | Yes | | | | |
+| `adalbert:deadline` | Yes | | | | | | |
+| `adalbert:recurrence` | Yes | | | | | | |
+| `adalbert:subject` | Yes | | | | | | |
+| `adalbert:object` | Yes | | | | | | |
+| `adalbert:subscribesTo` | | | Yes | | | | |
+| `adalbert:effectiveDate` | | Yes | Yes | | | | |
+| `adalbert:expirationDate` | | Yes | Yes | | | | |
+| `adalbert:resolutionPath` | | | | Yes | | | |
+| `adalbert:not` | | | | | Yes | | |
+| `adalbert:partOf` | | | | | | Yes | |
+| `adalbert:memberOf` | | | | | | | Yes |
+
+---
+
+## 8. Profile Constraints
+
+Adalbert restricts certain ODRL features:
+
+| Feature | Status | Reason |
+|---------|--------|--------|
+| `odrl:conflict` | Fixed to `odrl:prohibit` at profile level | Deterministic conflict resolution; declared once in `adalbert-prof.ttl` |
+| `odrl:xone` | Rejected | Deferred to RL2 |
+| `odrl:remedy` | Rejected | Deferred to RL2 |
+| `odrl:consequence` | Rejected | Deferred to RL2 |
+| `odrl:Ticket` | Not used | Not applicable to data governance |
+| `odrl:Request` | Not used | Not applicable |
+| `odrl:assignee` (on Duty) | Replaced by `adalbert:subject` | `adalbert:subject rdfs:subPropertyOf odrl:assignee` — avoids role overloading |
+| `odrl:AssetCollection` | Not used | Use `adalbert:partOf` hierarchy instead (`rdfs:subPropertyOf odrl:partOf` bridges to ODRL) |
+| `odrl:PartyCollection` | Not used | Use `adalbert:memberOf` hierarchy instead (`rdfs:subPropertyOf odrl:partOf` bridges to ODRL) |
+
+---
+
+**Version**: 0.7 | **Date**: 2026-02-04

--- a/adalbert-contracts/examples/baseline.ttl
+++ b/adalbert-contracts/examples/baseline.ttl
@@ -1,0 +1,732 @@
+# =============================================================================
+# Adalbert Baseline Test Data
+# =============================================================================
+# Comprehensive test dataset: 5 organizations, 8 assets, 8 DataContracts,
+# 2 Subscriptions, 6+ Duty instances with lifecycle state tracking.
+#
+# Covers all Adalbert patterns:
+#   - Recurring delivery with deadline
+#   - Schema conformance
+#   - Quality SLA (conformTo + constraint)
+#   - Change notification with lead time
+#   - Consumer reporting duty
+#   - Display / non-display / derivation permissions
+#   - Purpose, classification, environment constraints
+#   - Asset hierarchy (partOf) and party hierarchy (memberOf)
+#   - Contract versioning (prov:wasRevisionOf)
+#   - Subscription with bilateral duties
+# =============================================================================
+
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:         <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix prov:         <http://www.w3.org/ns/prov#> .
+
+# =============================================================================
+# ORGANIZATIONS (5 parties)
+# =============================================================================
+
+<https://data.bigbank/agents/data-platform> a odrl:Party ;
+    rdfs:label "Data Platform Team" .
+
+<https://data.bigbank/agents/trading-data> a odrl:Party ;
+    rdfs:label "Trading Data Team" ;
+    adalbert:memberOf <https://data.bigbank/agents/trading-division> .
+
+<https://data.bigbank/agents/trading-division> a odrl:Party ;
+    rdfs:label "Trading Division" .
+
+<https://data.bigbank/agents/analytics> a odrl:Party ;
+    rdfs:label "Analytics Team" ;
+    adalbert:memberOf <https://data.bigbank/agents/trading-division> .
+
+<https://data.bigbank/agents/finance> a odrl:Party ;
+    rdfs:label "Finance Team" .
+
+<https://data.bigbank/agents/hr> a odrl:Party ;
+    rdfs:label "HR Team" .
+
+# =============================================================================
+# ASSETS (8 assets with hierarchy)
+# =============================================================================
+
+<https://data.bigbank/assets/market-data-lake> a odrl:Asset ;
+    rdfs:label "Market Data Lake" .
+
+<https://data.bigbank/assets/market-prices> a odrl:Asset ;
+    rdfs:label "Market Price Data" ;
+    adalbert:partOf <https://data.bigbank/assets/market-data-lake> .
+
+<https://data.bigbank/assets/customer-data> a odrl:Asset ;
+    rdfs:label "Customer Data" .
+
+<https://data.bigbank/assets/reference-data> a odrl:Asset ;
+    rdfs:label "Reference Data" .
+
+<https://data.bigbank/assets/country-codes> a odrl:Asset ;
+    rdfs:label "Country Reference Table" ;
+    adalbert:partOf <https://data.bigbank/assets/reference-data> .
+
+<https://data.bigbank/assets/transaction-files> a odrl:Asset ;
+    rdfs:label "Transaction Files" .
+
+<https://data.bigbank/assets/employee-directory> a odrl:Asset ;
+    rdfs:label "Employee Directory" .
+
+<https://data.bigbank/assets/risk-metrics> a odrl:Asset ;
+    rdfs:label "Risk Metrics" .
+
+<https://data.bigbank/assets/audit-logs> a odrl:Asset ;
+    rdfs:label "Audit Log Archive" .
+
+<https://data.bigbank/assets/multi-asset-bundle> a odrl:Asset ;
+    rdfs:label "Multi-Asset Data Bundle" .
+
+# Ancillary assets (targets for duties)
+<https://data.bigbank/assets/customer-api-schema> a odrl:Asset ;
+    rdfs:label "Customer API Schema v2" .
+
+<https://data.bigbank/assets/market-data-schema> a odrl:Asset ;
+    rdfs:label "Market Data Schema" .
+
+<https://data.bigbank/assets/risk-metrics-schema> a odrl:Asset ;
+    rdfs:label "Risk Metrics Schema" .
+
+<https://data.bigbank/assets/schema-changes> a odrl:Asset ;
+    rdfs:label "Schema Change Notifications" .
+
+<https://data.bigbank/assets/usage-stats> a odrl:Asset ;
+    rdfs:label "Usage Statistics" .
+
+<https://data.bigbank/assets/monthly-report> a odrl:Asset ;
+    rdfs:label "Monthly Transaction Report" .
+
+# =============================================================================
+# CONTRACT 1: Customer API v2 (Daily delivery + recurrence + deadline + schema)
+# =============================================================================
+
+<https://data.bigbank/offers/customer-api-v1> a adalbert:DataContract ;
+    rdfs:label "Customer API v1 (retired)" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/customer-data> ;
+    adalbert:state adalbert:Fulfilled ;
+
+    # Retained from original contract (superseded by v2)
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:use
+    ] .
+
+<https://data.bigbank/offers/customer-api-v2> a adalbert:DataContract ;
+    rdfs:label "Customer API v2" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/customer-data> ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    prov:wasRevisionOf <https://data.bigbank/offers/customer-api-v1> ;
+
+    # Provider: daily delivery at 07:00 with 30-min window
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily customer data delivery" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform> ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=7;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # Provider: schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema conformance" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform> ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target <https://data.bigbank/assets/customer-api-schema>
+    ] ;
+
+    # Consumer: read
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: derive
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:derive ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:derivationType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:nonSubstitutive
+        ]
+    ] ;
+
+    # Consumer: monthly reporting
+    odrl:obligation [
+        a odrl:Duty ;
+        odrl:action adalbert-due:report ;
+        odrl:target <https://data.bigbank/assets/usage-stats> ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # No distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] .
+
+# =============================================================================
+# CONTRACT 2: Market Data Feed (High-frequency, display + nonDisplay)
+# =============================================================================
+
+<https://data.bigbank/offers/market-data-feed> a adalbert:DataContract ;
+    rdfs:label "Market Data Feed" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/trading-data> ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Provider: 15-minute delivery frequency
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "15-minute market data delivery" ;
+        adalbert:subject <https://data.bigbank/agents/trading-data> ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=MINUTELY;INTERVAL=15" ;
+        adalbert:deadline "PT5M"^^xsd:duration
+    ] ;
+
+    # Provider: schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Market data schema conformance" ;
+        adalbert:subject <https://data.bigbank/agents/trading-data> ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target <https://data.bigbank/assets/market-data-schema>
+    ] ;
+
+    # Consumer: display
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Display access" ;
+        odrl:action odrl:display
+    ] ;
+
+    # Consumer: non-display (internal only)
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Non-display use" ;
+        odrl:action adalbert-due:nonDisplay ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internal
+        ]
+    ] ;
+
+    # No external distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] .
+
+# =============================================================================
+# CONTRACT 3: Country Reference SQL (Simple read-only, no recurrence)
+# =============================================================================
+
+<https://data.bigbank/offers/country-ref> a adalbert:DataContract ;
+    rdfs:label "Country Reference Data" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/country-codes> ;
+    adalbert:state adalbert:Active ;
+
+    # Consumer: read only
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: query
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:query
+    ] ;
+
+    # No modification
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:modify
+    ] .
+
+# =============================================================================
+# CONTRACT 4: Transaction Files (Monthly delivery, consumer reporting)
+# =============================================================================
+
+<https://data.bigbank/offers/transaction-files> a adalbert:DataContract ;
+    rdfs:label "Transaction Files" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/finance> ;
+    odrl:target <https://data.bigbank/assets/transaction-files> ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+
+    # Provider: monthly file delivery
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Monthly transaction file delivery" ;
+        adalbert:subject <https://data.bigbank/agents/finance> ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=MONTHLY;BYMONTHDAY=1" ;
+        adalbert:deadline "P3D"^^xsd:duration
+    ] ;
+
+    # Consumer: read
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: monthly report submission
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Monthly reconciliation report" ;
+        odrl:action adalbert-due:report ;
+        odrl:target <https://data.bigbank/assets/monthly-report> ;
+        adalbert:recurrence "FREQ=MONTHLY;BYMONTHDAY=15" ;
+        adalbert:deadline "P5D"^^xsd:duration
+    ] ;
+
+    # No export outside system
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action adalbert-due:export
+    ] .
+
+# =============================================================================
+# CONTRACT 5: Employee Directory (Change notification, prohibition on distribute)
+# =============================================================================
+
+<https://data.bigbank/offers/employee-directory> a adalbert:DataContract ;
+    rdfs:label "Employee Directory" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/hr> ;
+    odrl:target <https://data.bigbank/assets/employee-directory> ;
+    adalbert:state adalbert:Active ;
+
+    # Provider: 90-day schema change notification
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema change notification (90 days)" ;
+        adalbert:subject <https://data.bigbank/agents/hr> ;
+        odrl:action adalbert-due:notify ;
+        odrl:target <https://data.bigbank/assets/schema-changes> ;
+        adalbert:deadline "P90D"^^xsd:duration
+    ] ;
+
+    # Consumer: read for operations purpose
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:operations
+        ]
+    ] ;
+
+    # No external distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute
+    ] ;
+
+    # No model training
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:use ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:processingMode ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:modelTraining
+        ]
+    ] .
+
+# =============================================================================
+# CONTRACT 6: Risk Metrics (Quality SLA via conformTo + constraint)
+# =============================================================================
+# This pattern replaces DCON's ProviderQualityPromise.
+
+<https://data.bigbank/offers/risk-metrics> a adalbert:DataContract ;
+    rdfs:label "Risk Metrics" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/risk-metrics> ;
+    adalbert:state adalbert:Active ;
+
+    # Provider: real-time delivery
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Real-time risk metrics delivery" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform> ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=MINUTELY;INTERVAL=1" ;
+        adalbert:deadline "PT30S"^^xsd:duration
+    ] ;
+
+    # Provider: quality SLA — schema conformance with timeliness constraint
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Quality SLA: real-time conformance" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform> ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target <https://data.bigbank/assets/risk-metrics-schema> ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:timeliness ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:realtime
+        ]
+    ] ;
+
+    # Provider: change notification (14 days)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema change notification" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform> ;
+        odrl:action adalbert-due:notify ;
+        odrl:target <https://data.bigbank/assets/schema-changes> ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+
+    # Consumer: display and non-display
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:display
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:nonDisplay
+    ] .
+
+# =============================================================================
+# CONTRACT 7: Audit Logs (Read-only, retention, purpose restriction)
+# =============================================================================
+
+<https://data.bigbank/offers/audit-logs> a adalbert:DataContract ;
+    rdfs:label "Audit Log Archive" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/audit-logs> ;
+    adalbert:state adalbert:Active ;
+
+    # Consumer: read for compliance only
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:compliance
+        ]
+    ] ;
+
+    # Retention: delete after 7 years
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "7-year retention limit" ;
+        odrl:action odrl:delete ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:retentionPeriod ;
+            odrl:operator odrl:gt ;
+            odrl:rightOperand "P7Y"^^xsd:duration
+        ]
+    ] ;
+
+    # No modification
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:modify
+    ] ;
+
+    # No export
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action adalbert-due:export
+    ] .
+
+# =============================================================================
+# CONTRACT 8: Multi-Asset Bundle (Multiple targets, multiple permissions)
+# =============================================================================
+
+<https://data.bigbank/offers/multi-asset> a adalbert:DataContract ;
+    rdfs:label "Multi-Asset Data Bundle" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:target <https://data.bigbank/assets/market-prices> ,
+               <https://data.bigbank/assets/reference-data> ,
+               <https://data.bigbank/assets/risk-metrics> ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Read all targets
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target <https://data.bigbank/assets/market-prices>
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target <https://data.bigbank/assets/reference-data>
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:read ;
+        odrl:target <https://data.bigbank/assets/risk-metrics>
+    ] ;
+
+    # Aggregate across targets
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:aggregate ;
+        odrl:target <https://data.bigbank/assets/multi-asset-bundle> ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:environment ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:production
+        ]
+    ] ;
+
+    # Non-display with internal-only constraint
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action adalbert-due:nonDisplay ;
+        odrl:target <https://data.bigbank/assets/multi-asset-bundle> ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internal
+        ]
+    ] ;
+
+    # No distribution of any target
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute ;
+        odrl:target <https://data.bigbank/assets/market-prices>
+    ] ;
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute ;
+        odrl:target <https://data.bigbank/assets/reference-data>
+    ] ;
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:action odrl:distribute ;
+        odrl:target <https://data.bigbank/assets/risk-metrics>
+    ] .
+
+
+# =============================================================================
+# SUBSCRIPTION 1: Analytics subscribes to Customer API v2
+# =============================================================================
+
+<https://data.bigbank/agreements/analytics-customer-2026> a adalbert:Subscription ;
+    rdfs:label "Analytics Customer Data 2026" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo <https://data.bigbank/offers/customer-api-v2> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform> ;
+    odrl:assignee <https://data.bigbank/agents/analytics> ;
+    odrl:target <https://data.bigbank/assets/customer-data> ;
+    adalbert:effectiveDate "2026-02-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # ----- Subject duties (provider) -----
+
+    odrl:obligation <https://data.bigbank/duties/cust-delivery-2026-001> ;
+    odrl:obligation <https://data.bigbank/duties/cust-schema-2026-001> ;
+
+    # ----- Assignee permissions -----
+    # Target inherited from policy (customer-data)
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action odrl:read
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action odrl:derive ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:derivationType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:nonSubstitutive
+        ]
+    ] ;
+
+    # ----- Subject duties (consumer) -----
+
+    odrl:obligation <https://data.bigbank/duties/cust-report-2026-001> ;
+
+    # ----- Prohibitions -----
+    # Target inherited from policy (customer-data)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# SUBSCRIPTION 2: Trading subscribes to Market Data Feed
+# =============================================================================
+
+<https://data.bigbank/agreements/trading-market-data-2026> a adalbert:Subscription ;
+    rdfs:label "Trading Market Data 2026" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo <https://data.bigbank/offers/market-data-feed> ;
+    odrl:assigner <https://data.bigbank/agents/trading-data> ;
+    odrl:assignee <https://data.bigbank/agents/analytics> ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:effectiveDate "2026-01-15T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # ----- Subject duties (provider) -----
+
+    odrl:obligation <https://data.bigbank/duties/mkt-delivery-2026-001> ;
+    odrl:obligation <https://data.bigbank/duties/mkt-schema-2026-001> ;
+
+    # ----- Assignee permissions -----
+    # Target inherited from policy (market-prices)
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action odrl:display
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action adalbert-due:nonDisplay ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internal
+        ]
+    ] ;
+
+    # ----- Prohibitions -----
+    # Target inherited from policy (market-prices)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:assignee <https://data.bigbank/agents/analytics> ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# DUTY INSTANCES (with lifecycle state tracking)
+# =============================================================================
+
+# --- Customer API duties ---
+
+<https://data.bigbank/duties/cust-delivery-2026-001> a odrl:Duty ;
+    rdfs:label "Customer data delivery (2026-02-04)" ;
+    adalbert:subject <https://data.bigbank/agents/data-platform> ;
+    adalbert:object <https://data.bigbank/agents/analytics> ;
+    odrl:action adalbert-due:deliver ;
+    odrl:target <https://data.bigbank/assets/customer-data> ;
+    adalbert:recurrence "FREQ=DAILY;BYHOUR=7;BYMINUTE=0" ;
+    adalbert:deadline "PT30M"^^xsd:duration ;
+    adalbert:state adalbert:Fulfilled .
+
+<https://data.bigbank/duties/cust-schema-2026-001> a odrl:Duty ;
+    rdfs:label "Customer API schema conformance" ;
+    adalbert:subject <https://data.bigbank/agents/data-platform> ;
+    adalbert:object <https://data.bigbank/agents/analytics> ;
+    odrl:action adalbert-due:conformTo ;
+    odrl:target <https://data.bigbank/assets/customer-api-schema> ;
+    adalbert:state adalbert:Active .
+
+<https://data.bigbank/duties/cust-report-2026-001> a odrl:Duty ;
+    rdfs:label "Analytics usage report (February)" ;
+    adalbert:subject <https://data.bigbank/agents/analytics> ;
+    adalbert:object <https://data.bigbank/agents/data-platform> ;
+    odrl:action adalbert-due:report ;
+    odrl:target <https://data.bigbank/assets/usage-stats> ;
+    adalbert:deadline "P30D"^^xsd:duration ;
+    adalbert:state adalbert:Active .
+
+# --- Market Data duties ---
+
+<https://data.bigbank/duties/mkt-delivery-2026-001> a odrl:Duty ;
+    rdfs:label "Market data delivery (latest interval)" ;
+    adalbert:subject <https://data.bigbank/agents/trading-data> ;
+    adalbert:object <https://data.bigbank/agents/analytics> ;
+    odrl:action adalbert-due:deliver ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:recurrence "FREQ=MINUTELY;INTERVAL=15" ;
+    adalbert:deadline "PT5M"^^xsd:duration ;
+    adalbert:state adalbert:Fulfilled .
+
+<https://data.bigbank/duties/mkt-schema-2026-001> a odrl:Duty ;
+    rdfs:label "Market data schema conformance" ;
+    adalbert:subject <https://data.bigbank/agents/trading-data> ;
+    adalbert:object <https://data.bigbank/agents/analytics> ;
+    odrl:action adalbert-due:conformTo ;
+    odrl:target <https://data.bigbank/assets/market-data-schema> ;
+    adalbert:state adalbert:Active .
+
+# --- A violated duty example ---
+
+<https://data.bigbank/duties/mkt-delivery-2026-late> a odrl:Duty ;
+    rdfs:label "Market data delivery (missed interval)" ;
+    adalbert:subject <https://data.bigbank/agents/trading-data> ;
+    odrl:action adalbert-due:deliver ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:recurrence "FREQ=MINUTELY;INTERVAL=15" ;
+    adalbert:deadline "PT5M"^^xsd:duration ;
+    adalbert:state adalbert:Violated .
+
+# =============================================================================
+# END OF BASELINE
+# =============================================================================

--- a/adalbert-contracts/examples/data-contract.ttl
+++ b/adalbert-contracts/examples/data-contract.ttl
@@ -1,0 +1,237 @@
+# =============================================================================
+# Example: Data Contract and Subscription
+# =============================================================================
+# Demonstrates bilateral agreement with subject/object duty party roles,
+# target inheritance, and ODRL terms for all standard constructs.
+# =============================================================================
+
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:         <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix prov:         <http://www.w3.org/ns/prov#> .
+
+# =============================================================================
+# PARTIES
+# =============================================================================
+
+<https://data.bigbank/agents/data-platform-team> a odrl:Party ;
+    rdfs:label "Data Platform Team" .
+
+<https://data.bigbank/agents/quant-research> a odrl:Party ;
+    rdfs:label "Quantitative Research" ;
+    adalbert:memberOf <https://data.bigbank/agents/trading-division> .
+
+<https://data.bigbank/agents/trading-division> a odrl:Party ;
+    rdfs:label "Trading Division" .
+
+# =============================================================================
+# ASSETS
+# =============================================================================
+
+<https://data.bigbank/assets/market-prices> a odrl:Asset ;
+    rdfs:label "Market Price Data" ;
+    adalbert:partOf <https://data.bigbank/assets/market-data-lake> .
+
+<https://data.bigbank/assets/market-data-lake> a odrl:Asset ;
+    rdfs:label "Market Data Lake" .
+
+<https://data.bigbank/assets/data-ready-notification> a odrl:Asset ;
+    rdfs:label "Data Ready Notification" .
+
+<https://data.bigbank/assets/schema-changes> a odrl:Asset ;
+    rdfs:label "Schema Changes" .
+
+<https://data.bigbank/assets/usage-stats> a odrl:Asset ;
+    rdfs:label "Usage Statistics" .
+
+# =============================================================================
+# DATA CONTRACT (Offer)
+# =============================================================================
+# This is the template offer from the data provider.
+# Subscribers accept this to create a Subscription (Agreement).
+#
+# Target inheritance: odrl:target at policy level is inherited by rules
+# unless overridden. Rules targeting a different asset declare their own target.
+
+<https://data.bigbank/offers/market-prices-v2> a adalbert:DataContract ;
+    rdfs:label "Market Price Data Contract v2" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform-team> ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    prov:wasRevisionOf <https://data.bigbank/offers/market-prices-v1> ;
+
+    # ----- PROVIDER COMMITMENTS (Subject Duties) -----
+
+    # SLA: Daily delivery by 6:30 AM (recurrence handles scheduling)
+    # Target inherited from policy (market-prices)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily data delivery" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform-team> ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # SLA: 14-day notice for schema changes
+    # Target differs from policy — schema-changes, not market-prices
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema change notification" ;
+        adalbert:subject <https://data.bigbank/agents/data-platform-team> ;
+        odrl:action adalbert-due:notify ;
+        odrl:target <https://data.bigbank/assets/schema-changes> ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+
+    # ----- CONSUMER RIGHTS (Permissions — assignee omitted in Offer) -----
+    # Target inherited from policy (market-prices)
+
+    # Display data
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Display access" ;
+        odrl:action odrl:display
+    ] ;
+
+    # Non-display (algorithmic) use
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Non-display use" ;
+        odrl:action adalbert-due:nonDisplay ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internal
+        ]
+    ] ;
+
+    # Derive (create derived products)
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Derivation rights" ;
+        odrl:action odrl:derive
+    ] ;
+
+    # ----- CONSUMER OBLIGATIONS (Duties — subject omitted in Offer) -----
+
+    # Monthly usage reporting
+    # Target differs from policy — usage-stats, not market-prices
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Usage reporting" ;
+        odrl:action adalbert-due:report ;
+        odrl:target <https://data.bigbank/assets/usage-stats> ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # ----- RESTRICTIONS (Prohibitions) -----
+    # Target inherited from policy (market-prices)
+
+    # No external distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No redistribution" ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# SUBSCRIPTION (Agreement)
+# =============================================================================
+# Quant Research has subscribed to the data contract.
+# This is a bilateral agreement with duties on BOTH parties.
+# Target inherited from policy (market-prices) unless overridden.
+
+<https://data.bigbank/agreements/quant-market-data-2026> a adalbert:Subscription ;
+    rdfs:label "Quant Research Market Data 2026" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo <https://data.bigbank/offers/market-prices-v2> ;
+    odrl:assigner <https://data.bigbank/agents/data-platform-team> ;
+    odrl:assignee <https://data.bigbank/agents/quant-research> ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:effectiveDate "2026-01-15T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # ===== SUBJECT DUTIES (Data Team's Obligations) =====
+
+    odrl:obligation <https://data.bigbank/duties/delivery-2026-001> ;
+    odrl:obligation <https://data.bigbank/duties/notify-2026-001> ;
+
+    # ===== ASSIGNEE PERMISSIONS (Quant's Rights) =====
+    # Target inherited from policy (market-prices)
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/quant-research> ;
+        odrl:action odrl:display
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/quant-research> ;
+        odrl:action adalbert-due:nonDisplay
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee <https://data.bigbank/agents/quant-research> ;
+        odrl:action odrl:derive
+    ] ;
+
+    # ===== SUBJECT DUTIES (Quant's Obligations) =====
+
+    odrl:obligation <https://data.bigbank/duties/report-2026-001> ;
+
+    # ===== PROHIBITIONS =====
+    # Target inherited from policy (market-prices)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:assignee <https://data.bigbank/agents/quant-research> ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# DUTY INSTANCES (with lifecycle state)
+# =============================================================================
+# These are instantiated from the contract clauses with tracked state.
+
+# Subject duty: Daily delivery (instance for 2026-01-15)
+<https://data.bigbank/duties/delivery-2026-001> a odrl:Duty ;
+    rdfs:label "Daily delivery duty (2026-01-15)" ;
+    adalbert:subject <https://data.bigbank/agents/data-platform-team> ;
+    adalbert:object <https://data.bigbank/agents/quant-research> ;
+    odrl:action adalbert-due:deliver ;
+    odrl:target <https://data.bigbank/assets/market-prices> ;
+    adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+    adalbert:deadline "PT30M"^^xsd:duration ;
+    adalbert:state adalbert:Fulfilled .  # Successfully delivered
+
+# Subject duty: Schema change notification
+<https://data.bigbank/duties/notify-2026-001> a odrl:Duty ;
+    rdfs:label "Schema notification duty" ;
+    adalbert:subject <https://data.bigbank/agents/data-platform-team> ;
+    adalbert:object <https://data.bigbank/agents/quant-research> ;
+    odrl:action adalbert-due:notify ;
+    odrl:target <https://data.bigbank/assets/schema-changes> ;
+    adalbert:deadline "P14D"^^xsd:duration ;
+    adalbert:state adalbert:Pending .  # No schema change yet
+
+# Subject duty: Monthly reporting
+<https://data.bigbank/duties/report-2026-001> a odrl:Duty ;
+    rdfs:label "January usage report" ;
+    adalbert:subject <https://data.bigbank/agents/quant-research> ;
+    adalbert:object <https://data.bigbank/agents/data-platform-team> ;
+    odrl:action adalbert-due:report ;
+    odrl:target <https://data.bigbank/assets/usage-stats> ;
+    adalbert:deadline "P30D"^^xsd:duration ;
+    adalbert:state adalbert:Active .  # Due date approaching

--- a/adalbert-contracts/examples/data-use-policy.ttl
+++ b/adalbert-contracts/examples/data-use-policy.ttl
@@ -1,0 +1,213 @@
+# =============================================================================
+# Example: Internal Data Access Policy
+# =============================================================================
+# Shows role-based access with purpose constraints and consent tracking,
+# using ODRL terms for all standard constructs.
+# Target inheritance: policy-level odrl:target is inherited by rules unless
+# overridden at rule level.
+# =============================================================================
+
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:         <http://www.w3.org/2000/01/rdf-schema#> .
+
+# =============================================================================
+# PARTIES (Hierarchy)
+# =============================================================================
+
+<https://data.bigbank/agents/hr-analytics> a odrl:Party ;
+    rdfs:label "HR Analytics Team" ;
+    adalbert:memberOf <https://data.bigbank/agents/hr-division> .
+
+<https://data.bigbank/agents/hr-division> a odrl:Party ;
+    rdfs:label "Human Resources Division" .
+
+<https://data.bigbank/agents/compliance-team> a odrl:Party ;
+    rdfs:label "Compliance Team" .
+
+# =============================================================================
+# ASSETS (Hierarchy)
+# =============================================================================
+
+<https://data.bigbank/assets/employee-compensation> a odrl:Asset ;
+    rdfs:label "Employee Compensation Data" ;
+    adalbert:partOf <https://data.bigbank/assets/employee-data> .
+
+<https://data.bigbank/assets/employee-performance> a odrl:Asset ;
+    rdfs:label "Employee Performance Reviews" ;
+    adalbert:partOf <https://data.bigbank/assets/employee-data> .
+
+<https://data.bigbank/assets/employee-data> a odrl:Asset ;
+    rdfs:label "Employee Data Lake" .
+
+<https://data.bigbank/assets/access-log> a odrl:Asset ;
+    rdfs:label "Access Log" .
+
+# =============================================================================
+# POLICY SET: HR Data Access Controls
+# =============================================================================
+# This is a Set (no parties) — applies to anyone matching the conditions.
+# Target inheritance: rules inherit employee-data target unless overridden.
+
+<https://data.bigbank/policies/hr-data-access> a odrl:Set ;
+    rdfs:label "HR Data Access Policy" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:target <https://data.bigbank/assets/employee-data> ;
+
+    # ===== RULE 1: HR Analytics can read for analytics purposes =====
+    # Target inherited from policy (employee-data)
+
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "HR analytics read access" ;
+        odrl:assignee <https://data.bigbank/agents/hr-analytics> ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:analytics
+        ]
+    ] ;
+
+    # ===== RULE 2: Compliance can read for compliance purposes =====
+    # Target inherited from policy (employee-data)
+
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Compliance audit access" ;
+        odrl:assignee <https://data.bigbank/agents/compliance-team> ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:compliance
+        ]
+    ] ;
+
+    # ===== RULE 3: Anyone reading must log access =====
+    # Target differs from policy — access-log, not employee-data
+
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Mandatory audit logging" ;
+        odrl:action adalbert-due:log ;
+        odrl:target <https://data.bigbank/assets/access-log> ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:classification ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:confidential
+        ] ;
+        adalbert:deadline "PT1H"^^xsd:duration  # Log within 1 hour
+    ] ;
+
+    # ===== RULE 4: No external distribution =====
+    # Target inherited from policy (employee-data)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No external sharing" ;
+        odrl:action odrl:distribute
+    ] ;
+
+    # ===== RULE 5: No use for model training =====
+    # Target inherited from policy (employee-data)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No ML training" ;
+        odrl:action odrl:use ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:processingMode ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:modelTraining
+        ]
+    ] ;
+
+    # ===== RULE 6: Production only =====
+    # Target inherited from policy (employee-data)
+
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "Production and staging only" ;
+        odrl:action odrl:use ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:environment ;
+            odrl:operator odrl:isNoneOf ;
+            odrl:rightOperand (adalbert-due:production adalbert-due:staging)
+        ]
+    ] .
+
+
+# =============================================================================
+# POLICY SET: Compensation Data (Stricter)
+# =============================================================================
+# More restrictive policy for sensitive compensation data.
+# Target inheritance: rules inherit employee-compensation target.
+
+<https://data.bigbank/policies/compensation-access> a odrl:Set ;
+    rdfs:label "Compensation Data Access Policy" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:target <https://data.bigbank/assets/employee-compensation> ;
+
+    # Only HR Division (not just analytics sub-team)
+    # Target inherited from policy (employee-compensation)
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "HR Division compensation access" ;
+        odrl:assignee <https://data.bigbank/agents/hr-division> ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand odrl:purpose ;
+                    odrl:operator odrl:isAnyOf ;
+                    odrl:rightOperand (adalbert-due:compliance adalbert-due:operations)
+                ]
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:legalBasis ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand adalbert-due:legitimateInterest
+                ]
+            )
+        ]
+    ] ;
+
+    # Retention limit: delete after 7 years
+    # Target inherited from policy (employee-compensation)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Retention limit" ;
+        odrl:action odrl:delete ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:retentionPeriod ;
+            odrl:operator odrl:gt ;
+            odrl:rightOperand "P7Y"^^xsd:duration
+        ]
+    ] ;
+
+    # Mandatory anonymization for any analytics
+    # Target inherited from policy (employee-compensation)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Anonymization required" ;
+        odrl:action odrl:anonymize ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:analytics
+        ]
+    ] .

--- a/adalbert-contracts/examples/dprod-translated.ttl
+++ b/adalbert-contracts/examples/dprod-translated.ttl
@@ -1,0 +1,1083 @@
+# =============================================================================
+# DPROD-Contracts to Adalbert Translation
+# =============================================================================
+# Translates the 8 dprod-contracts examples into Adalbert syntax.
+#
+# Key translation principles:
+#   - dprod:DataContract / dprod:DataOffer -> adalbert:DataContract (subClassOf odrl:Offer)
+#   - dprod:Promise / dprod:ProviderPromise -> odrl:Duty with adalbert:subject = provider
+#   - dprod:ConsumerPromise -> odrl:Permission, odrl:Prohibition, or odrl:Duty
+#   - dprod:contractStatus -> adalbert:state
+#   - dprod:hasEffectivePeriod -> adalbert:effectiveDate + adalbert:expirationDate
+#   - dprod:hasSchedule / icalRule -> adalbert:recurrence (direct RRULE string)
+#   - dprod:noticePeriod -> adalbert:deadline (as xsd:duration)
+#   - dprod:supersedes -> prov:wasRevisionOf
+#
+# Adalbert uses ODRL vocabulary directly for standard constructs (Permission,
+# Prohibition, Duty, Constraint) and extends only where ODRL has gaps (State,
+# deadline, recurrence, subject/object party roles, DataContract).
+#
+# Scope note: Adalbert intentionally does not address pricing. dprod-contracts
+# has dprod:hasPricing with schema:PriceSpecification for marketplace scenarios;
+# Adalbert focuses on rights, obligations, and constraints. Example 8 translates
+# access tiers as permissions with subscriptionTier constraints, but pricing
+# metadata remains outside Adalbert's scope.
+#
+# Every policy declares:
+#   odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+#                <https://vocabulary.bigbank/adalbert/due/> ;
+#
+# Target inheritance: odrl:target at policy level is inherited by all rules
+# unless a rule overrides with its own odrl:target.
+# =============================================================================
+
+@prefix odrl:         <http://www.w3.org/ns/odrl/2/> .
+@prefix adalbert:     <https://vocabulary.bigbank/adalbert/> .
+@prefix adalbert-due: <https://vocabulary.bigbank/adalbert/due/> .
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:         <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix prov:         <http://www.w3.org/ns/prov#> .
+@prefix dcat:         <http://www.w3.org/ns/dcat#> .
+@prefix dct:          <http://purl.org/dc/terms/> .
+@prefix sh:           <http://www.w3.org/ns/shacl#> .
+@prefix ex:           <https://example.com/> .
+
+
+# =============================================================================
+# PARTIES
+# =============================================================================
+
+ex:sales-team a odrl:Party ;
+    rdfs:label "Sales Data Team" .
+
+ex:revenue-team a odrl:Party ;
+    rdfs:label "Revenue Data Team" .
+
+ex:clickstream-team a odrl:Party ;
+    rdfs:label "Clickstream Data Team" .
+
+ex:ml-team a odrl:Party ;
+    rdfs:label "ML Engineering Team" .
+
+ex:segments-team a odrl:Party ;
+    rdfs:label "Customer Segments Team" .
+
+ex:marketing a odrl:Party ;
+    rdfs:label "Marketing Division" .
+
+ex:api-platform a odrl:Party ;
+    rdfs:label "API Platform Team" .
+
+ex:quality-team a odrl:Party ;
+    rdfs:label "Data Quality Team" .
+
+ex:support-team a odrl:Party ;
+    rdfs:label "Support Operations Team" .
+
+ex:marketplace-provider a odrl:Party ;
+    rdfs:label "Data Marketplace Provider" .
+
+
+# =============================================================================
+# ASSETS
+# =============================================================================
+
+ex:sales-data a odrl:Asset ;
+    rdfs:label "Sales Transaction Data" .
+
+ex:revenue-data a odrl:Asset ;
+    rdfs:label "Revenue Reporting Data" .
+
+ex:revenue-schema a odrl:Asset ;
+    rdfs:label "Revenue Data Schema v3" .
+
+ex:revenue-changes a odrl:Asset ;
+    rdfs:label "Revenue Schema Change Notifications" .
+
+ex:clickstream-data a odrl:Asset ;
+    rdfs:label "Clickstream Event Data" .
+
+ex:attribution-report a odrl:Asset ;
+    rdfs:label "Attribution Report" .
+
+ex:segments-data a odrl:Asset ;
+    rdfs:label "Customer Segments Data" .
+
+ex:segments-schema a odrl:Asset ;
+    rdfs:label "Customer Segments Schema" .
+
+ex:segments-changes a odrl:Asset ;
+    rdfs:label "Segments Schema Change Notifications" .
+
+ex:segments-usage a odrl:Asset ;
+    rdfs:label "Segments Usage Statistics" .
+
+ex:api-data a odrl:Asset ;
+    rdfs:label "API Service Data" .
+
+ex:api-schema a odrl:Asset ;
+    rdfs:label "API Schema v2" .
+
+ex:product-catalog a odrl:Asset ;
+    rdfs:label "Product Catalog Data" .
+
+ex:product-schema a odrl:Asset ;
+    rdfs:label "Product Catalog Schema" .
+
+ex:product-quality-report a odrl:Asset ;
+    rdfs:label "Product Quality Report" .
+
+ex:crm-data a odrl:Asset ;
+    rdfs:label "CRM Integration Data" .
+
+ex:crm-changes a odrl:Asset ;
+    rdfs:label "CRM Change Notifications" .
+
+ex:geo-data a odrl:Asset ;
+    rdfs:label "Geospatial Analytics Data" .
+
+ex:geo-schema a odrl:Asset ;
+    rdfs:label "Geospatial Data Schema" .
+
+ex:geo-sample a odrl:Asset ;
+    rdfs:label "Geospatial Sample Dataset" .
+
+
+# =============================================================================
+# EXAMPLE 1: Minimal Data Contract (Sales Data)
+# =============================================================================
+# DPROD original: dprod:DataContract with contractStatus Active, a single
+# provider promise (deliverOnSchedule), and basic consumer access.
+#
+# Translation:
+#   dprod:DataContract           -> adalbert:DataContract
+#   dprod:contractStatus Active  -> adalbert:state adalbert:Active
+#   dprod:deliverOnSchedule      -> odrl:Duty with adalbert-due:deliver
+#   dprod:access (consumer)      -> odrl:Permission with odrl:use
+# =============================================================================
+
+ex:contract-sales-minimal a adalbert:DataContract ;
+    rdfs:label "Sales Data Contract (Minimal)" ;
+    dct:description "Minimal data contract providing daily sales data access." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:sales-team ;
+    odrl:target ex:sales-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+
+    # Provider duty: daily delivery at 08:00 with 1-hour window
+    # DPROD: dprod:providerPromise [ a dprod:ProviderTimelinessPromise ;
+    #            dprod:hasSchedule [ dprod:icalRule "FREQ=DAILY;BYHOUR=8" ] ]
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily sales data delivery" ;
+        adalbert:subject ex:sales-team ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=8;BYMINUTE=0" ;
+        adalbert:deadline "PT1H"^^xsd:duration
+    ] ;
+
+    # Consumer permission: general use
+    # DPROD: dprod:consumerPromise [ dprod:access ]
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Sales data access" ;
+        odrl:action odrl:use
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 2: Provider Promises (Revenue Data)
+# =============================================================================
+# DPROD original: dprod:DataContract with three provider promises:
+#   - ProviderTimelinessPromise (deliverOnSchedule, hourly)
+#   - ProviderSchemaPromise (maintainSchema)
+#   - ProviderTerminationNoticePromise (notifyTermination, 90-day notice)
+#
+# Translation:
+#   ProviderTimelinessPromise   -> odrl:Duty + adalbert-due:deliver + recurrence
+#   ProviderSchemaPromise       -> odrl:Duty + adalbert-due:conformTo
+#   ProviderTerminationNotice   -> odrl:Duty + adalbert-due:notify + deadline
+#   All provider promises use adalbert:subject to identify the duty bearer.
+# =============================================================================
+
+ex:contract-revenue-promises a adalbert:DataContract ;
+    rdfs:label "Revenue Data Contract (Provider Promises)" ;
+    dct:description "Revenue reporting data with timeliness, schema, and termination promises." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:revenue-team ;
+    odrl:target ex:revenue-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Provider duty: hourly delivery with 15-minute window
+    # DPROD: dprod:ProviderTimelinessPromise with FREQ=HOURLY schedule
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Hourly revenue data delivery" ;
+        adalbert:subject ex:revenue-team ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=HOURLY" ;
+        adalbert:deadline "PT15M"^^xsd:duration
+    ] ;
+
+    # Provider duty: schema conformance
+    # DPROD: dprod:ProviderSchemaPromise with dprod:maintainSchema
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Revenue schema conformance" ;
+        adalbert:subject ex:revenue-team ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:revenue-schema
+    ] ;
+
+    # Provider duty: 90-day termination notice
+    # DPROD: dprod:ProviderTerminationNoticePromise with dprod:noticePeriod P90D
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Termination notice (90 days)" ;
+        adalbert:subject ex:revenue-team ;
+        odrl:action adalbert-due:notify ;
+        odrl:target ex:revenue-changes ;
+        adalbert:deadline "P90D"^^xsd:duration
+    ] ;
+
+    # Consumer: read access (implied by DPROD data contract)
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Revenue data read access" ;
+        odrl:action odrl:read
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 3: Consumer Promises (Clickstream ML)
+# =============================================================================
+# DPROD original: dprod:DataContract with consumer promises:
+#   - query (access method)
+#   - deriveInsights (ML use case)
+#   - provideAttribution (consumer obligation)
+#   - deleteOnExpiry (consumer obligation)
+#   - restrictPurpose: no redistribution (prohibition)
+#
+# Translation:
+#   dprod:query           -> odrl:Permission with adalbert-due:query
+#   dprod:deriveInsights  -> odrl:Permission with odrl:derive
+#   dprod:provideAttribution -> odrl:Duty with adalbert-due:report (attribution)
+#   dprod:deleteOnExpiry  -> odrl:Duty with odrl:delete
+#   dprod:restrictPurpose -> odrl:Prohibition on odrl:distribute
+#
+# In an Offer, consumer duties omit adalbert:subject (filled upon subscription).
+# Consumer permissions omit odrl:assignee (filled upon subscription).
+# =============================================================================
+
+ex:contract-clickstream-ml a adalbert:DataContract ;
+    rdfs:label "Clickstream ML Contract (Consumer Promises)" ;
+    dct:description "Clickstream data for ML insights with attribution, deletion, and redistribution constraints." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:clickstream-team ;
+    odrl:target ex:clickstream-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-02-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2027-01-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Consumer permission: query access
+    # DPROD: dprod:consumerPromise [ dprod:query ]
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Query access" ;
+        odrl:action adalbert-due:query
+    ] ;
+
+    # Consumer permission: derive insights (ML purpose constraint)
+    # DPROD: dprod:consumerPromise [ dprod:deriveInsights ]
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Derive ML insights" ;
+        odrl:action odrl:derive ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand odrl:purpose ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:analytics
+        ]
+    ] ;
+
+    # Consumer duty: provide attribution (monthly)
+    # DPROD: dprod:consumerPromise [ dprod:provideAttribution ]
+    # No adalbert:subject in Offer -- filled upon subscription
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Monthly attribution report" ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:attribution-report ;
+        adalbert:recurrence "FREQ=MONTHLY;BYMONTHDAY=1" ;
+        adalbert:deadline "P5D"^^xsd:duration
+    ] ;
+
+    # Consumer duty: delete data on contract expiry
+    # DPROD: dprod:consumerPromise [ dprod:deleteOnExpiry ]
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Delete data on expiry" ;
+        odrl:action odrl:delete ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # Prohibition: no redistribution
+    # DPROD: dprod:consumerPromise [ dprod:restrictPurpose "no redistribution" ]
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No redistribution" ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 4: Full Lifecycle (Customer Segments)
+# =============================================================================
+# DPROD original: Full lifecycle with dprod:DataOffer + dprod:DataContract +
+# versioning (dprod:supersedes) + all promise types:
+#   - ProviderTimelinessPromise (daily delivery)
+#   - ProviderSchemaPromise (schema conformance)
+#   - ProviderChangeNotificationPromise (14-day notice)
+#   - ProviderTerminationNoticePromise (60-day notice)
+#   - Consumer: access, derive, reportUsage, deleteOnExpiry, no redistribute
+#
+# Translation:
+#   dprod:DataOffer -> adalbert:DataContract (Adalbert unifies offer/contract)
+#   dprod:supersedes -> prov:wasRevisionOf
+#   dprod:contractStatus Pending -> adalbert:state adalbert:Pending
+#   dprod:contractStatus Active  -> adalbert:state adalbert:Active
+#   dprod:contractStatus Expired -> adalbert:state adalbert:Fulfilled
+#
+# This example shows both the retired v1 and active v2, plus a subscription.
+# =============================================================================
+
+# --- V1: Retired (Fulfilled) ---
+
+ex:contract-segments-v1 a adalbert:DataContract ;
+    rdfs:label "Customer Segments v1 (retired)" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:segments-team ;
+    odrl:target ex:segments-data ;
+    adalbert:state adalbert:Fulfilled ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:action odrl:use
+    ] .
+
+# --- V2: Active ---
+
+ex:contract-segments-v2 a adalbert:DataContract ;
+    rdfs:label "Customer Segments v2" ;
+    dct:description "Full lifecycle contract with all provider and consumer promise types." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:segments-team ;
+    odrl:target ex:segments-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+    prov:wasRevisionOf ex:contract-segments-v1 ;
+
+    # ----- PROVIDER DUTIES -----
+
+    # Daily delivery at 06:00 with 30-minute window
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily segments delivery" ;
+        adalbert:subject ex:segments-team ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # Schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema conformance" ;
+        adalbert:subject ex:segments-team ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:segments-schema
+    ] ;
+
+    # 14-day change notification
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema change notification (14 days)" ;
+        adalbert:subject ex:segments-team ;
+        odrl:action adalbert-due:notify ;
+        odrl:target ex:segments-changes ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+
+    # 60-day termination notice
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Termination notice (60 days)" ;
+        adalbert:subject ex:segments-team ;
+        odrl:action adalbert-due:notify ;
+        adalbert:deadline "P60D"^^xsd:duration
+    ] ;
+
+    # ----- CONSUMER PERMISSIONS -----
+
+    # Read access
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Segments read access" ;
+        odrl:action odrl:read
+    ] ;
+
+    # Derive insights
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Derive from segments" ;
+        odrl:action odrl:derive
+    ] ;
+
+    # ----- CONSUMER DUTIES -----
+
+    # Monthly usage reporting
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Monthly usage reporting" ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:segments-usage ;
+        adalbert:recurrence "FREQ=MONTHLY;BYMONTHDAY=5" ;
+        adalbert:deadline "P5D"^^xsd:duration
+    ] ;
+
+    # Delete on expiry
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Delete data on contract expiry" ;
+        odrl:action odrl:delete ;
+        adalbert:deadline "P30D"^^xsd:duration
+    ] ;
+
+    # ----- PROHIBITION -----
+
+    # No redistribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No redistribution" ;
+        odrl:action odrl:distribute
+    ] .
+
+# --- Subscription: Marketing subscribes to v2 ---
+
+ex:subscription-marketing-segments a adalbert:Subscription ;
+    rdfs:label "Marketing Segments Subscription 2026" ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    adalbert:subscribesTo ex:contract-segments-v2 ;
+    odrl:assigner ex:segments-team ;
+    odrl:assignee ex:marketing ;
+    odrl:target ex:segments-data ;
+    adalbert:effectiveDate "2026-02-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Provider duties (with adalbert:subject + adalbert:object)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily segments delivery" ;
+        adalbert:subject ex:segments-team ;
+        adalbert:object ex:marketing ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=6;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Schema conformance" ;
+        adalbert:subject ex:segments-team ;
+        adalbert:object ex:marketing ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:segments-schema
+    ] ;
+
+    # Consumer duty (assignee is duty bearer in subscription)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Monthly usage reporting" ;
+        adalbert:subject ex:marketing ;
+        adalbert:object ex:segments-team ;
+        odrl:action adalbert-due:report ;
+        odrl:target ex:segments-usage ;
+        adalbert:recurrence "FREQ=MONTHLY;BYMONTHDAY=5" ;
+        adalbert:deadline "P5D"^^xsd:duration
+    ] ;
+
+    # Consumer permissions
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee ex:marketing ;
+        odrl:action odrl:read
+    ] ;
+
+    odrl:permission [
+        a odrl:Permission ;
+        odrl:assignee ex:marketing ;
+        odrl:action odrl:derive
+    ] ;
+
+    # Prohibition
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        odrl:assignee ex:marketing ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 5: Service Level Promise (API with SLAs)
+# =============================================================================
+# DPROD original: dprod:ProviderServiceLevelPromise with SLA targets:
+#   - availability >= 99.9%
+#   - latency (p99) <= 200ms
+#   - throughput >= 1000 req/s
+#
+# Translation:
+#   dprod:meetServiceLevel -> odrl:Duty + adalbert-due:conformTo + constraints
+#   SLA metrics are expressed as odrl:Constraint on the conformTo duty.
+#   Each metric is a separate constraint combined with odrl:and.
+#
+# Adalbert expresses SLAs as conformance duties with measurable constraints,
+# not as a separate promise class.
+# =============================================================================
+
+ex:contract-api-sla a adalbert:DataContract ;
+    rdfs:label "API Service Level Contract" ;
+    dct:description "API data contract with availability, latency, and throughput SLAs." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:api-platform ;
+    odrl:target ex:api-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Provider duty: schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "API schema conformance" ;
+        adalbert:subject ex:api-platform ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:api-schema
+    ] ;
+
+    # Provider duty: SLA conformance (availability + latency + throughput)
+    # DPROD: dprod:ProviderServiceLevelPromise with dprod:meetServiceLevel
+    # Adalbert: single conformTo duty with compound constraint
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Service level conformance" ;
+        adalbert:subject ex:api-platform ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "Availability >= 99.9%" ;
+                    odrl:leftOperand adalbert-due:availability ;
+                    odrl:operator odrl:gteq ;
+                    odrl:rightOperand "99.9"^^xsd:decimal
+                ]
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "P99 latency <= 200ms" ;
+                    odrl:leftOperand adalbert-due:latency ;
+                    odrl:operator odrl:lteq ;
+                    odrl:rightOperand "PT0.2S"^^xsd:duration
+                ]
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "Throughput >= 1000 req/s" ;
+                    odrl:leftOperand adalbert-due:throughput ;
+                    odrl:operator odrl:gteq ;
+                    odrl:rightOperand "1000"^^xsd:integer
+                ]
+            )
+        ]
+    ] ;
+
+    # Provider duty: 14-day change notification
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "API change notification (14 days)" ;
+        adalbert:subject ex:api-platform ;
+        odrl:action adalbert-due:notify ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+
+    # Consumer: read
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "API read access" ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: query
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "API query access" ;
+        odrl:action adalbert-due:query
+    ] ;
+
+    # No external distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No redistribution" ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 6: Data Quality Promise (Product Catalog)
+# =============================================================================
+# DPROD original: dprod:DataContract with dprod:ProviderQualityPromise
+# specifying quality metrics (completeness, accuracy, freshness).
+#
+# Translation:
+#   dprod:maintainQuality -> odrl:Duty + adalbert-due:conformTo with quality
+#   constraints.  Each quality dimension is an odrl:Constraint.
+#   Adalbert has no separate quality promise class; quality SLAs are
+#   conformTo duties with measurable constraints, same pattern as SLAs.
+# =============================================================================
+
+ex:contract-product-quality a adalbert:DataContract ;
+    rdfs:label "Product Catalog Quality Contract" ;
+    dct:description "Product catalog with data quality guarantees: completeness, accuracy, and freshness." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:quality-team ;
+    odrl:target ex:product-catalog ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+
+    # Provider duty: daily delivery
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily product catalog delivery" ;
+        adalbert:subject ex:quality-team ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=5;BYMINUTE=0" ;
+        adalbert:deadline "PT1H"^^xsd:duration
+    ] ;
+
+    # Provider duty: schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Product catalog schema conformance" ;
+        adalbert:subject ex:quality-team ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:product-schema
+    ] ;
+
+    # Provider duty: data quality conformance
+    # DPROD: dprod:ProviderQualityPromise with dprod:maintainQuality
+    # Adalbert: conformTo duty with compound quality constraint
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Data quality conformance" ;
+        adalbert:subject ex:quality-team ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:product-quality-report ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "Completeness >= 99.5%" ;
+                    odrl:leftOperand adalbert-due:completeness ;
+                    odrl:operator odrl:gteq ;
+                    odrl:rightOperand "99.5"^^xsd:decimal
+                ]
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "Accuracy >= 99.0%" ;
+                    odrl:leftOperand adalbert-due:accuracy ;
+                    odrl:operator odrl:gteq ;
+                    odrl:rightOperand "99.0"^^xsd:decimal
+                ]
+                [
+                    a odrl:Constraint ;
+                    rdfs:label "Freshness: data no older than 24 hours" ;
+                    odrl:leftOperand adalbert-due:timeliness ;
+                    odrl:operator odrl:lteq ;
+                    odrl:rightOperand "PT24H"^^xsd:duration
+                ]
+            )
+        ]
+    ] ;
+
+    # Consumer: read
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Product catalog read access" ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: query
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Product catalog query access" ;
+        odrl:action adalbert-due:query
+    ] ;
+
+    # No modification by consumer
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No modification" ;
+        odrl:action odrl:modify
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 7: Support Promise (Multi-Channel CRM)
+# =============================================================================
+# DPROD original: dprod:ProviderSupportPromise with multi-channel support:
+#   - email support (response within 4 hours)
+#   - chat support (response within 30 minutes)
+#   - phone support (business hours)
+#
+# Translation:
+#   dprod:provideSupport -> not directly mappable. Adalbert is lighter.
+#   Express as odrl:Duty with adalbert-due:notify for each support channel,
+#   using constraints to specify channel type and response time deadlines.
+#
+#   Each support channel becomes a separate notify duty with a deadline
+#   representing the response time SLA.
+# =============================================================================
+
+ex:contract-crm-support a adalbert:DataContract ;
+    rdfs:label "CRM Integration Support Contract" ;
+    dct:description "CRM data integration with multi-channel support: email, chat, and phone." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:support-team ;
+    odrl:target ex:crm-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+    adalbert:expirationDate "2026-12-31T23:59:59Z"^^xsd:dateTime ;
+
+    # Provider duty: daily delivery
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily CRM data delivery" ;
+        adalbert:subject ex:support-team ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=7;BYMINUTE=0" ;
+        adalbert:deadline "PT30M"^^xsd:duration
+    ] ;
+
+    # Provider duty: schema change notification
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "CRM schema change notification" ;
+        adalbert:subject ex:support-team ;
+        odrl:action adalbert-due:notify ;
+        odrl:target ex:crm-changes ;
+        adalbert:deadline "P14D"^^xsd:duration
+    ] ;
+
+    # Support channel: email (4-hour response)
+    # DPROD: dprod:ProviderSupportPromise [ dprod:channel "email" ;
+    #            dprod:responseTime "PT4H" ]
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Email support response" ;
+        adalbert:subject ex:support-team ;
+        odrl:action adalbert-due:notify ;
+        adalbert:deadline "PT4H"^^xsd:duration ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:channel ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "email"
+        ]
+    ] ;
+
+    # Support channel: chat (30-minute response)
+    # DPROD: dprod:ProviderSupportPromise [ dprod:channel "chat" ;
+    #            dprod:responseTime "PT30M" ]
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Chat support response" ;
+        adalbert:subject ex:support-team ;
+        odrl:action adalbert-due:notify ;
+        adalbert:deadline "PT30M"^^xsd:duration ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:channel ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "chat"
+        ]
+    ] ;
+
+    # Support channel: phone (business hours, 1-hour response)
+    # DPROD: dprod:ProviderSupportPromise [ dprod:channel "phone" ;
+    #            dprod:responseTime "PT1H" ; dprod:availability "business hours" ]
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Phone support response (business hours)" ;
+        adalbert:subject ex:support-team ;
+        odrl:action adalbert-due:notify ;
+        adalbert:deadline "PT1H"^^xsd:duration ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:channel ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand "phone"
+                ]
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:serviceWindow ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand "business-hours"
+                ]
+            )
+        ]
+    ] ;
+
+    # Consumer: read
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "CRM data read access" ;
+        odrl:action odrl:read
+    ] ;
+
+    # Consumer: modify (integration updates)
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "CRM data modification" ;
+        odrl:action odrl:modify ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:internalRecipient
+        ]
+    ] ;
+
+    # No external distribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No external distribution" ;
+        odrl:action odrl:distribute
+    ] .
+
+
+# =============================================================================
+# EXAMPLE 8: Marketplace Offer with Pricing (Geospatial Data)
+# =============================================================================
+# DPROD original: dprod:DataOffer published on a marketplace with:
+#   - pricing tier (expressed as constraint on access)
+#   - free sample tier (no constraint)
+#   - premium tier (paid, with derive + aggregate + internal sharing)
+#   - provider promises (timeliness, schema, SLA)
+#
+# Translation:
+#   dprod:DataOffer -> adalbert:DataContract (Adalbert unifies these)
+#   Pricing tiers -> separate permissions with constraints
+#   dprod:download -> odrl:Permission with odrl:read (or odrl:reproduce)
+#   dprod:stream -> odrl:Permission with odrl:read
+#   dprod:aggregate -> odrl:Permission with odrl:aggregate
+#   dprod:shareInternally -> odrl:Permission with odrl:distribute + internal constraint
+#   dprod:enrich -> odrl:Permission with odrl:modify
+#
+# Adalbert does not model pricing directly. Access tiers are expressed
+# as permissions with constraints on access level or subscription tier.
+# =============================================================================
+
+ex:contract-geo-marketplace a adalbert:DataContract ;
+    rdfs:label "Geospatial Analytics Marketplace Offer" ;
+    dct:description "Marketplace data offer with free sample and premium tiers for geospatial analytics." ;
+    odrl:profile <https://vocabulary.bigbank/adalbert/> ,
+                 <https://vocabulary.bigbank/adalbert/due/> ;
+    odrl:assigner ex:marketplace-provider ;
+    odrl:target ex:geo-data ;
+    adalbert:state adalbert:Active ;
+    adalbert:effectiveDate "2026-01-01T00:00:00Z"^^xsd:dateTime ;
+
+    # ----- PROVIDER DUTIES -----
+
+    # Daily delivery
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Daily geospatial data delivery" ;
+        adalbert:subject ex:marketplace-provider ;
+        odrl:action adalbert-due:deliver ;
+        adalbert:recurrence "FREQ=DAILY;BYHOUR=4;BYMINUTE=0" ;
+        adalbert:deadline "PT1H"^^xsd:duration
+    ] ;
+
+    # Schema conformance
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Geospatial schema conformance" ;
+        adalbert:subject ex:marketplace-provider ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:target ex:geo-schema
+    ] ;
+
+    # SLA: 99.5% availability
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Availability SLA" ;
+        adalbert:subject ex:marketplace-provider ;
+        odrl:action adalbert-due:conformTo ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:availability ;
+            odrl:operator odrl:gteq ;
+            odrl:rightOperand "99.5"^^xsd:decimal
+        ]
+    ] ;
+
+    # ----- FREE TIER PERMISSIONS -----
+    # DPROD: dprod:download on sample dataset (no pricing constraint)
+
+    # Free: read sample data
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Free tier: sample read access" ;
+        odrl:action odrl:read ;
+        odrl:target ex:geo-sample
+    ] ;
+
+    # ----- PREMIUM TIER PERMISSIONS -----
+    # DPROD: dprod:stream, dprod:aggregate, dprod:enrich, dprod:shareInternally
+    # Adalbert: permissions with subscription tier constraint
+
+    # Premium: read (streaming access to full dataset)
+    # DPROD: dprod:stream
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Premium: streaming read access" ;
+        odrl:action odrl:read ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:subscriptionTier ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "premium"
+        ]
+    ] ;
+
+    # Premium: derive insights
+    # DPROD: dprod:deriveInsights
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Premium: derive insights" ;
+        odrl:action odrl:derive ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:subscriptionTier ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "premium"
+        ]
+    ] ;
+
+    # Premium: aggregate
+    # DPROD: dprod:aggregate
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Premium: aggregate" ;
+        odrl:action odrl:aggregate ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:subscriptionTier ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "premium"
+        ]
+    ] ;
+
+    # Premium: enrich (modify with additional data)
+    # DPROD: dprod:enrich
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Premium: enrich data" ;
+        odrl:action odrl:modify ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:subscriptionTier ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand "premium"
+        ]
+    ] ;
+
+    # Premium: internal sharing only
+    # DPROD: dprod:shareInternally
+    odrl:permission [
+        a odrl:Permission ;
+        rdfs:label "Premium: internal distribution" ;
+        odrl:action odrl:distribute ;
+        odrl:constraint [
+            a odrl:LogicalConstraint ;
+            odrl:and (
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:subscriptionTier ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand "premium"
+                ]
+                [
+                    a odrl:Constraint ;
+                    odrl:leftOperand adalbert-due:recipientType ;
+                    odrl:operator odrl:eq ;
+                    odrl:rightOperand adalbert-due:internalRecipient
+                ]
+            )
+        ]
+    ] ;
+
+    # ----- CONSUMER DUTIES -----
+
+    # Usage reporting (all tiers)
+    odrl:obligation [
+        a odrl:Duty ;
+        rdfs:label "Quarterly usage reporting" ;
+        odrl:action adalbert-due:report ;
+        adalbert:recurrence "FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1" ;
+        adalbert:deadline "P10D"^^xsd:duration
+    ] ;
+
+    # ----- PROHIBITIONS -----
+
+    # No external redistribution
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No external redistribution" ;
+        odrl:action odrl:distribute ;
+        odrl:constraint [
+            a odrl:Constraint ;
+            odrl:leftOperand adalbert-due:recipientType ;
+            odrl:operator odrl:eq ;
+            odrl:rightOperand adalbert-due:externalRecipient
+        ]
+    ] ;
+
+    # No anonymization and resale
+    odrl:prohibition [
+        a odrl:Prohibition ;
+        rdfs:label "No anonymize-and-resell" ;
+        odrl:action odrl:anonymize
+    ] .
+
+
+# =============================================================================
+# END OF DPROD TRANSLATION
+# =============================================================================


### PR DESCRIPTION
## Summary

- Contributes **Adalbert** as a complementary approach to `dprod-contracts`, using standard ODRL 2.2 `Permission`, `Duty`, and `Prohibition` types (no custom Rule subclasses)
- Adds **data-use policies** (`odrl:Set`) for organizational access control — role-based permissions, purpose restrictions, classification constraints — alongside bilateral data contracts
- Includes **formal evaluation semantics** (normative specification amenable to Dafny/Why3/Coq verification)
- Translates all 8 `dprod-contracts` examples into Adalbert syntax (`examples/dprod-translated.ttl`), demonstrating compatibility
- Provides a detailed comparison document (`docs/DPROD-Adalbert-Comparison.md`) with class/property/action mapping tables

## What's included

| File | Description |
|------|-------------|
| `adalbert-core.ttl` | OWL ontology (ODRL profile extension) |
| `adalbert-shacl.ttl` | SHACL validation shapes |
| `adalbert-prof.ttl` | W3C DXPROF profile metadata |
| `adalbert-due.ttl` | Data use vocabulary (33 operands, domain-specific actions) |
| `examples/data-contract.ttl` | Bilateral contract with provider SLA + consumer duties |
| `examples/data-use-policy.ttl` | Role-based access control with purpose constraints |
| `examples/baseline.ttl` | Comprehensive test suite (8 contracts, 2 subscriptions) |
| `examples/dprod-translated.ttl` | All 8 dprod-contracts examples in Adalbert |
| `docs/SPECIFICATION.md` | Technical vocabulary reference |
| `docs/SEMANTICS.md` | Formal evaluation semantics (normative) |
| `docs/DATA-CONTRACTS.md` | Contract authoring guide |
| `docs/DATA-USE-POLICIES.md` | Policy authoring guide |
| `docs/DPROD-Adalbert-Comparison.md` | Side-by-side comparison with dprod-contracts |

## Key architectural difference

dprod-contracts introduces `dprod:Promise` as a new `odrl:Rule` subclass. Adalbert uses standard `odrl:Duty` for all obligations, distinguishing provider from consumer duties via `adalbert:subject`. Every Adalbert policy is a valid ODRL 2.2 policy that any ODRL processor can partially understand.

## Scope note

Adalbert intentionally does not address pricing (dprod-contracts has `dprod:hasPricing`). Adalbert focuses on rights, obligations, and constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)