### PR TITLE
Ballot 4: add Retire to DataProductLifecycleStatus (#28)

### DIFF
--- a/ontology/dprod/dprod-ontology.ttl
+++ b/ontology/dprod/dprod-ontology.ttl
@@ -54,7 +54,7 @@ dprod:DataProduct
 dprod:DataProductLifecycleStatus
   a owl:Class, rdfs:Class ;
   dct:description
-    "The development status of the data product taken from a controlled list (e.g. Ideation, Design, Build, Deploy, Consume)."@en ;
+    "The development status of the data product taken from a controlled list (e.g. Ideation, Design, Build, Deploy, Consume, Retire)."@en ;
   rdfs:comment "The lifecycle of the data product as defined by EDM Council CDMC"@en ;
   rdfs:isDefinedBy dprod: ;
   rdfs:label "data product lifecycle status" ;

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -125,7 +125,7 @@ dprod-shapes:InformationSensitivityClassificationShape
 dprod-shapes:DataProductLifecycleStatusShape
     a sh:NodeShape;
     rdfs:label "data product lifecycle status shape" ;
-    dct:description "The development status of the data product taken from a controlled list (e.g. Ideation, Design, Build, Deploy, Consume)."@en ;
+    dct:description "The development status of the data product taken from a controlled list (e.g. Ideation, Design, Build, Deploy, Consume, Retire)."@en ;
     sh:targetClass dprod:DataProductLifecycleStatus;
     rdfs:isDefinedBy dprod-shapes:;
   .


### PR DESCRIPTION
Merges DPROD-17 into ballot/4.

**Issue:** #28 — Include a terminal state for the Data Product

**Changes:**
- `ontology/dprod/dprod-ontology.ttl`: add Retire to DataProductLifecycleStatus enumeration
- `ontology/dprod/dprod-shapes.ttl`: align shapes with ontology

Part of ballot/4 consolidation (DPROD-16, DPROD-17, DPROD-18, DPROD-20, joshcornejo-patch-2 → ballot/4).

Made with [Cursor](https://cursor.com)