### PR TITLE
Ballot 4: add dprod-shapes prefix to normative namespaces (#29)

### DIFF
--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -17,7 +17,6 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix sdo: <http://schema.org/> .
 
 dprod-shapes:
   a owl:Ontology ;

--- a/respec/template.html
+++ b/respec/template.html
@@ -599,6 +599,15 @@
     </tr>
     <tr>
       <td>
+        <code>dprod-shapes</code>
+      </td>
+      <td>
+        <code>https://ekgf.github.io/dprod/shapes/</code>
+      </td>
+      <td>[[dprod]]</td>
+    </tr>
+    <tr>
+      <td>
         <code>dcat</code>
       </td>
       <td>


### PR DESCRIPTION
Merges DPROD-16 into ballot/4.

**Issue:** #29 — define dprod: prefix in namespace section

**Changes:**
- `ontology/dprod/dprod-shapes.ttl`: namespace/prefix for shapes
- `respec/template.html`: add dprod-shapes prefix to normative namespaces table

Part of ballot/4 consolidation (DPROD-16, DPROD-17, DPROD-18, DPROD-20, joshcornejo-patch-2 → ballot/4).

Made with [Cursor](https://cursor.com)