### PR TITLE
Ballot 4: prevent SHACL shape labels leaking into spec (#79)

### DIFF
--- a/spec-generator/globals.py
+++ b/spec-generator/globals.py
@@ -13,6 +13,7 @@ LINKEDIN = Namespace(linkedin_ns_iri)
 
 IGNORED_NODE_SHAPE_PREDICATES = (
     RDF.type,
+    RDFS.label,
     RDFS.isDefinedBy,
     SKOS.altLabel,
     SKOS.changeNote,

--- a/spec-generator/main.py
+++ b/spec-generator/main.py
@@ -64,7 +64,6 @@ def main():
     g_shapes = load_dprod_shapes()
     
     jsonld_context_ontology = {
-<<<<<<< HEAD
             "@version": 1.1,
             "dprod": ontology_namespace_iri,
             "xsd": str(XSD),


### PR DESCRIPTION
Merges DPROD-18 into ballot/4.

**Issue:** #79 — Use of "shape" in rdfs:label of shapes makes its way into spec

**Changes:**
- `spec-generator/globals.py`: ignore shape-related predicates so SHACL labels don't leak
- `spec-generator/main.py`: align with globals

Part of ballot/4 consolidation (DPROD-16, DPROD-17, DPROD-18, DPROD-20, joshcornejo-patch-2 → ballot/4).

Made with [Cursor](https://cursor.com)