### PR TITLE
Ballot 4: remove dprod:Protocol class (DPROD-33, #143)

### DIFF
--- a/ontology/dprod/dprod-ontology.ttl
+++ b/ontology/dprod/dprod-ontology.ttl
@@ -78,13 +78,6 @@ dprod:Enumeration
   rdfs:label "enumeration" ;
 .
 
-dprod:Protocol
-  a owl:Class, rdfs:Class ;
-  dct:description "A detailed specification, possibly including a specific version, for how to communicate with a service."@en ;
-  rdfs:isDefinedBy dprod: ;
-  rdfs:label "protocol" ;
-.
-
 dprod:SecuritySchemaType
   a owl:Class, rdfs:Class ;
   dct:description "A classification encompassing a set of rules used for authentication and communication."@en ;
@@ -211,7 +204,7 @@ dprod:protocol
   dct:description "A protocol (possibly one of many options) used to communicate with this data service."@en ;
   rdfs:isDefinedBy dprod: ;
   rdfs:domain dcat:DataService ;
-# rdfs:range rdf:resource ; # better let user decide whether they want Protocol class or own class or skos
+# rdfs:range not specified; users reference external URIs or SKOS concepts (DPROD-33)
   rdfs:label "protocol" ;
 .
 

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -130,14 +130,6 @@ dprod-shapes:DataProductLifecycleStatusShape
     rdfs:isDefinedBy dprod-shapes:;
   .
 
-dprod-shapes:ProtocolShape
-    a sh:NodeShape;
-    rdfs:label "protocol shape" ;
-    dct:description "A detailed specification, possibly including a specific version, for how to communicate with a service."@en ;
-    rdfs:isDefinedBy dprod-shapes:;
-    sh:targetClass dprod:Protocol;
-.
-
 dprod-shapes:SecuritySchemaTypeShape
     a sh:NodeShape;
     rdfs:label "security schema type shape" ;
@@ -362,7 +354,6 @@ dprod-shapes:DataService-protocol
   a sh:PropertyShape;
   rdfs:isDefinedBy dprod-shapes:;
   sh:path dprod:protocol;
-  sh:class dcat:Protocol;
   dct:description "A protocol (possibly one of many options) used to communicate with this data service."@en ;
   rdfs:label "data service protocol shape" ;
   .

--- a/spec-generator/main.py
+++ b/spec-generator/main.py
@@ -47,7 +47,6 @@ def main():
         'Dataset',
         'DataProductLifecycleStatus',
         'InformationSensitivityClassification',
-        'Protocol',
         'SecuritySchemaType',
         'Enumeration'
     ])


### PR DESCRIPTION
## Summary
- Removes the `dprod:Protocol` OWL class, resolving the modeling question in #143 (part of #98).
- `dprod:protocol` now points to a URI / SKOS concept rather than an under-specified class.

Resolves: DPROD-33, Closes #143

## Test plan
- [ ] `bash build.sh` succeeds
- [ ] Generated spec in `dist/index.html` no longer references `dprod:Protocol`
- [ ] Examples still validate against updated shapes