### PR TITLE
feat(site): add OMG logo to header matching ekgf.org alignment

### DIFF
--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes";
 import { Moon, Sun, Github } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { EkgfLogoSymbol } from "@/components/icons/EkgfLogoSymbol";
+import { OmgLogo } from "@/components/icons/OmgLogo";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -77,6 +78,16 @@ export function Header() {
               <Github className="h-5 w-5" />
             </a>
           </Button>
+
+          <a
+            href="https://omg.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Object Management Group (OMG)"
+            className="hidden sm:flex items-center rounded-md px-2 py-1 opacity-80 hover:opacity-100 transition-opacity transform -translate-y-1"
+          >
+            <OmgLogo className="h-[1.65rem] w-auto" />
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
Mirrors the OMG logo placement from \`ekgf-website/src/components/Header.tsx\` exactly — same classes, same transform, same opacity transitions, same vertical offset. Appears to the right of the GitHub icon on screens sm and up.

## Preview
https://dprod-git-feat-header-omg-logo-ekgf.vercel.app/