### PR TITLE
Multi-zone: serve under /dprod basePath (#174)

### DIFF
--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -5,6 +5,9 @@ import { getSpecVersions } from "@/lib/spec-versions";
  * Matches anything under /spec/<something>/..., so the middleware fires for
  * cross-branch spec routing. /spec and /spec/ (no suffix) fall through to
  * Next.js's normal static serving (current deployment's public/spec/).
+ *
+ * basePath /dprod is auto-applied by Next.js, so this matcher effectively
+ * becomes /dprod/spec/:path+ in the wire URL.
  */
 export const config = {
   matcher: "/spec/:path+",
@@ -15,10 +18,20 @@ export const config = {
 //   - "archive"  → static files under public/spec/archive
 const STATIC_SLUGS = new Set(["main", "archive"]);
 
+/**
+ * Parse /spec/<slug>[/<rest>] — accepting an optional leading basePath so
+ * the regex works whether or not Next.js has already stripped it.
+ */
+function parseSpecPath(pathname: string): { slug: string; rest: string } | null {
+  const match = pathname.match(/^(?:\/dprod)?\/spec\/([^/]+)(\/.*)?$/);
+  if (!match) return null;
+  return { slug: match[1], rest: match[2] ?? "" };
+}
+
 export async function middleware(req: NextRequest) {
-  const match = req.nextUrl.pathname.match(/^\/spec\/([^/]+)(\/.*)?$/);
-  if (!match) return NextResponse.next();
-  const [, slug, rest = ""] = match;
+  const parsed = parseSpecPath(req.nextUrl.pathname);
+  if (!parsed) return NextResponse.next();
+  const { slug, rest } = parsed;
 
   if (STATIC_SLUGS.has(slug)) return NextResponse.next();
 
@@ -27,20 +40,16 @@ export async function middleware(req: NextRequest) {
   if (!version || version.kind !== "vercel-branch") return NextResponse.next();
 
   // If the requested version matches the current deployment, serve locally
-  // via same-origin rewrite — assets resolve normally.
+  // via same-origin rewrite — assets resolve normally. The destination must
+  // include the basePath because req.nextUrl.pathname is wire-level.
   if (version.isCurrent) {
     const url = req.nextUrl.clone();
-    url.pathname = `/spec${rest}`;
+    url.pathname = `/dprod/spec${rest}`;
     return NextResponse.rewrite(url);
   }
 
-  // For cross-branch targets we 307 to the actual deployment URL instead of
-  // proxy-rewriting. NextResponse.rewrite() to an external origin returns
-  // the HTML body but does NOT rewrite the /_next/static/... asset paths
-  // inside it — the browser then fetches assets from the current origin
-  // (where the hashed filenames don't exist) and the page renders unstyled.
-  // A redirect loses the /spec/<slug> URL in the address bar but everything
-  // works. A future route handler could do HTML rewriting with <base> tag
-  // injection for unified chrome, but not in phase 5.
+  // For cross-branch targets we 307 to the actual deployment URL. The
+  // origin already includes /dprod (see spec-versions.ts) so we only append
+  // /spec<rest>.
   return NextResponse.redirect(`${version.origin}/spec${rest}`, 307);
 }

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,9 +1,34 @@
 import type { NextConfig } from "next";
 
+/**
+ * Multi-zone configuration.
+ *
+ * The dprod site is served as a Next.js zone under the /dprod path prefix.
+ * The primary zone (ekgf-website) rewrites /dprod/:path* to whichever
+ * deployment of this project it's targeting. When that happens the HTML
+ * has absolute asset URLs back to this deployment's origin so CSS and JS
+ * resolve across the zone boundary.
+ *
+ * basePath:   all routes, rewrites, middleware matcher paths are served
+ *             under /dprod.
+ * assetPrefix: every /_next/static/... URL in the generated HTML is
+ *             absolute to this deployment's own origin. We read
+ *             VERCEL_URL at build time (unique per deployment, always
+ *             reachable) and prepend https://. On local dev VERCEL_URL
+ *             is undefined and assetPrefix falls back to relative paths
+ *             so localhost:3000 still works.
+ */
+const vercelUrl = process.env.VERCEL_URL;
+const assetPrefix = vercelUrl ? `https://${vercelUrl}` : undefined;
+
 const nextConfig: NextConfig = {
+  basePath: "/dprod",
+  assetPrefix,
   async rewrites() {
     return [
       // /spec → current deployment's own generated spec
+      // (basePath is automatically prepended, so this resolves to
+      // /dprod/spec → /dprod/spec/index.html under the zone.)
       { source: "/spec", destination: "/spec/index.html" },
       // /spec/main → frozen OMG 1.0 archive
       { source: "/spec/main", destination: "/spec/archive/1.0/index.html" },

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -1,12 +1,20 @@
 import Link from "next/link";
 import { Github } from "lucide-react";
 
-const NAV_LINKS = [
+/**
+ * Cross-zone nav items that escape the /dprod basePath back to ekgf.org.
+ * Rendered as plain `<a>` tags.
+ */
+const EKGF_LINKS = [
   { href: "/about", label: "About" },
   { href: "/quadrants", label: "Quadrants" },
   { href: "/resources", label: "Resources" },
   { href: "/membership", label: "Membership" },
   { href: "/contact", label: "Contact" },
+];
+
+/** In-zone links rendered with Next.js Link (basePath auto-prefixed). */
+const DPROD_LINKS = [
   { href: "/spec-versions", label: "Specification" },
 ];
 
@@ -36,7 +44,17 @@ export function Footer() {
           <div>
             <h3 className="mb-4 text-lg font-semibold">Navigate</h3>
             <ul className="space-y-2 text-sm">
-              {NAV_LINKS.map(({ href, label }) => (
+              {EKGF_LINKS.map(({ href, label }) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
+              {DPROD_LINKS.map(({ href, label }) => (
                 <li key={href}>
                   <Link
                     href={href}

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -13,12 +13,25 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 
-const NAV_ITEMS = [
+/**
+ * Items that belong to the EKGF primary zone (ekgf.org). They're rendered
+ * as plain `<a>` tags with root-relative hrefs so the Next.js basePath
+ * ("/dprod") is NOT prepended — clicking these escapes the dprod zone
+ * back to the ekgf.org routes that serve them.
+ */
+const EKGF_NAV = [
   { href: "/about", label: "About" },
   { href: "/quadrants", label: "Quadrants" },
   { href: "/resources", label: "Resources" },
   { href: "/membership", label: "Membership" },
   { href: "/contact", label: "Contact" },
+] as const;
+
+/**
+ * Items that live inside this zone. Rendered with Next.js `<Link>` so the
+ * "/dprod" basePath is automatically prepended.
+ */
+const DPROD_NAV = [
   { href: "/spec-versions", label: "Specification" },
 ] as const;
 
@@ -26,10 +39,11 @@ export function Header() {
   const { theme, setTheme } = useTheme();
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/20 bg-background/90 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full border-b border-border/20 bg-background/90">
       <div className="container flex h-20 items-center justify-between">
         <div className="flex items-center gap-8">
-          <Link
+          {/* Brand link escapes the dprod zone back to ekgf.org root. */}
+          <a
             href="/"
             className="group flex items-center text-3xl leading-none transform -translate-y-1.5"
           >
@@ -39,11 +53,21 @@ export function Header() {
                 EKGF
               </span>
             </span>
-          </Link>
+          </a>
 
           <NavigationMenu className="hidden md:flex">
             <NavigationMenuList>
-              {NAV_ITEMS.map(({ href, label }) => (
+              {EKGF_NAV.map(({ href, label }) => (
+                <NavigationMenuItem key={href}>
+                  <NavigationMenuLink
+                    asChild
+                    className={navigationMenuTriggerStyle()}
+                  >
+                    <a href={href}>{label}</a>
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+              ))}
+              {DPROD_NAV.map(({ href, label }) => (
                 <NavigationMenuItem key={href}>
                   <NavigationMenuLink
                     asChild

--- a/site/src/lib/spec-versions.ts
+++ b/site/src/lib/spec-versions.ts
@@ -122,12 +122,15 @@ export async function getSpecVersions(): Promise<SpecVersion[]> {
     seen.add(branch);
 
     const slug = branchToSlug(branch);
+    // NOTE: the origin intentionally includes the /dprod basePath so the
+    // middleware redirect lands on the zone root, not the deployment
+    // root (which is a 404 under multi-zone).
     versions.push({
       id: slug,
       label: labelForBranch(branch),
       description: descriptionForBranch(branch),
       branch,
-      origin: `https://dprod-git-${slug}-ekgf.vercel.app`,
+      origin: `https://dprod-git-${slug}-ekgf.vercel.app/dprod`,
       isCurrent: branch === currentBranch,
       isProduction: branch === "develop",
       kind: "vercel-branch",


### PR DESCRIPTION
## Summary
Turns the dprod site into a Next.js **secondary zone** served under \`/dprod\`. Companion PR in ekgf-website adds the rewrite that forwards \`/dprod/*\` from the primary zone into this deployment.

Why: "all looking like one site (but with multiple repos backing it)." Same pattern extends later to maturity, method, catalog, principles, etc.

## Changes
- \`site/next.config.ts\`: \`basePath: "/dprod"\` + \`assetPrefix\` computed from \`VERCEL_URL\` so every \`/_next/static/...\` URL in the HTML is absolute to this deployment's own origin. This is what lets CSS/JS resolve when the HTML is served via cross-origin rewrite from ekgf.org.
- \`site/middleware.ts\`: regex parses paths with an optional leading \`/dprod\`, and the same-origin self-rewrite path is constructed as \`/dprod/spec${'$'}{rest}\` because \`req.nextUrl.pathname\` is wire-level.
- \`site/src/lib/spec-versions.ts\`: cross-branch \`origin\` now includes \`/dprod\` so the 307 redirect lands on the zone root (not the deployment root, which is now a 404).
- \`site/src/components/Header.tsx\`: nav is split into
  - \`EKGF_NAV\` rendered with plain \`<a>\` so basePath is NOT applied — clicking About, Quadrants, Resources, Membership, Contact escapes back to ekgf.org routes
  - \`DPROD_NAV\` rendered with \`<Link>\` — Specification stays in-zone
  The brand link in the upper left also becomes \`<a href="/">\` so it returns to the ekgf.org home.
- \`site/src/components/Footer.tsx\`: same split.

## Verification
Deployed at https://dprod-git-feat-multi-zone-ekgf.vercel.app

Direct access (bypassing ekgf.org):

| URL | Expected |
|---|---|
| \`/\` | 404 (zone root is \`/dprod\`, not \`/\`) |
| \`/dprod\` | 200 landing |
| \`/dprod/spec-versions\` | 200 picker |
| \`/dprod/spec\` | 200 current branch's generated spec |
| \`/dprod/spec/main\` | 200 OMG 1.0 archive |

End-to-end via the ekgf-website preview (feat/dprod-multi-zone rewriting \`/dprod/*\` here via \`DPROD_ZONE_ORIGIN\` env var):

| URL | Result |
|---|---|
| \`ekgf-website-git-feat-dprod-multi-zone-ekgf.vercel.app/dprod\` | HTTP 200, title \`DPROD — Data Product Ontology\` ✓ |
| Same, assets | absolute URLs back to \`dprod-*.vercel.app/_next/...\` ✓ |

## Depends on
Must merge **before** EKGF/ekgf-website#17-replacement, otherwise ekgf.org/dprod returns 404 because \`dprod.ekgf.vercel.app/\` (root) will no longer serve anything — the canonical URL shifts to \`dprod.ekgf.vercel.app/dprod\`.

## Not in scope
- Phase 6 polish (OG image, sitemap, a11y)
- Extracting the pattern into a shared helper for future zones (maturity, method, ...)