### PR TITLE
fix(site): include /dprod basePath in assetPrefix (#174)

### DIFF
--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -19,7 +19,12 @@ import type { NextConfig } from "next";
  *             so localhost:3000 still works.
  */
 const vercelUrl = process.env.VERCEL_URL;
-const assetPrefix = vercelUrl ? `https://${vercelUrl}` : undefined;
+// IMPORTANT: include the /dprod basePath in the assetPrefix. With basePath
+// set, Next.js serves _next/* assets at /dprod/_next/*, but assetPrefix is
+// written to the HTML as-is without the basePath being re-appended, so we
+// have to include it ourselves or every asset 404s across the zone
+// boundary.
+const assetPrefix = vercelUrl ? `https://${vercelUrl}/dprod` : undefined;
 
 const nextConfig: NextConfig = {
   basePath: "/dprod",


### PR DESCRIPTION
## Problem
After #180 merged, \`ekgf.org/dprod\` rendered the giant-unstyled-logo view again — every CSS/JS asset was 404ing.

Root cause: with \`basePath: "/dprod"\`, Next.js serves internal \`_next/*\` assets at \`/dprod/_next/*\`, but \`assetPrefix\` is written into the generated HTML as-is — **Next.js does NOT re-append basePath to URLs formed via assetPrefix**. So the HTML emitted URLs like

\`\`\`
https://dprod-xxx.vercel.app/_next/static/chunks/70939e3db6163f29.css
\`\`\`

which 404, because the file actually lives at

\`\`\`
https://dprod-xxx.vercel.app/dprod/_next/static/chunks/70939e3db6163f29.css
\`\`\`

## Fix
Append \`/dprod\` to \`assetPrefix\` so generated asset URLs include the basePath segment.

## Verification
Preview at https://dprod-git-fix-asset-prefix-basepath-ekgf.vercel.app — asset URLs in the HTML now resolve 200:

\`\`\`
href="https://dprod-adbe910f7-ekgf.vercel.app/dprod/_next/static/chunks/...css"  → HTTP 200
\`\`\`

Needs to merge promptly to unbreak production \`ekgf.org/dprod\`.