### PR TITLE
fix(site): /dprod/spec/<current-branch> returning 404 (#174)

### DIFF
--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -62,15 +62,18 @@ export async function middleware(req: NextRequest) {
   // rewrite to the static index.html inside public/spec/ under basePath.
   // We bypass the /spec -> /spec/index.html rewrite from next.config.ts
   // because chaining middleware rewrites through afterFiles rewrites is
-  // unreliable in Next.js 16.
+  // unreliable in Next.js 16. We also construct the destination URL via
+  // `new URL(path, req.url)` rather than `req.nextUrl.clone()` because
+  // NextURL carries a basePath attribute and mutating its pathname leads
+  // to double-prefix surprises.
   if (version.isCurrent) {
-    const url = req.nextUrl.clone();
-    url.pathname = rest
+    const destPath = rest
       ? `/dprod/spec${rest}`
       : `/dprod/spec/index.html`;
-    return withDebug(NextResponse.rewrite(url), "self-rewrite", {
+    const destUrl = new URL(destPath, req.url);
+    return withDebug(NextResponse.rewrite(destUrl), "self-rewrite", {
       slug,
-      dest: url.pathname,
+      dest: destPath,
     });
   }
 

--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -28,28 +28,58 @@ function parseSpecPath(pathname: string): { slug: string; rest: string } | null 
   return { slug: match[1], rest: match[2] ?? "" };
 }
 
+function withDebug(
+  res: NextResponse,
+  tag: string,
+  extras: Record<string, string | undefined> = {},
+): NextResponse {
+  res.headers.set("x-dprod-mw", tag);
+  for (const [k, v] of Object.entries(extras)) {
+    if (v !== undefined) res.headers.set(`x-dprod-mw-${k}`, v);
+  }
+  return res;
+}
+
 export async function middleware(req: NextRequest) {
   const parsed = parseSpecPath(req.nextUrl.pathname);
-  if (!parsed) return NextResponse.next();
+  if (!parsed) return withDebug(NextResponse.next(), "no-match");
   const { slug, rest } = parsed;
 
-  if (STATIC_SLUGS.has(slug)) return NextResponse.next();
+  if (STATIC_SLUGS.has(slug)) {
+    return withDebug(NextResponse.next(), "static-slug", { slug });
+  }
 
   const versions = await getSpecVersions();
   const version = versions.find((v) => v.id === slug);
-  if (!version || version.kind !== "vercel-branch") return NextResponse.next();
+  if (!version || version.kind !== "vercel-branch") {
+    return withDebug(NextResponse.next(), "unknown-slug", {
+      slug,
+      versions: versions.map((v) => v.id).join(","),
+    });
+  }
 
-  // If the requested version matches the current deployment, serve locally
-  // via same-origin rewrite — assets resolve normally. The destination must
-  // include the basePath because req.nextUrl.pathname is wire-level.
+  // If the requested version matches the current deployment, directly
+  // rewrite to the static index.html inside public/spec/ under basePath.
+  // We bypass the /spec -> /spec/index.html rewrite from next.config.ts
+  // because chaining middleware rewrites through afterFiles rewrites is
+  // unreliable in Next.js 16.
   if (version.isCurrent) {
     const url = req.nextUrl.clone();
-    url.pathname = `/dprod/spec${rest}`;
-    return NextResponse.rewrite(url);
+    url.pathname = rest
+      ? `/dprod/spec${rest}`
+      : `/dprod/spec/index.html`;
+    return withDebug(NextResponse.rewrite(url), "self-rewrite", {
+      slug,
+      dest: url.pathname,
+    });
   }
 
   // For cross-branch targets we 307 to the actual deployment URL. The
   // origin already includes /dprod (see spec-versions.ts) so we only append
   // /spec<rest>.
-  return NextResponse.redirect(`${version.origin}/spec${rest}`, 307);
+  return withDebug(
+    NextResponse.redirect(`${version.origin}/spec${rest}`, 307),
+    "cross-branch",
+    { slug, origin: version.origin },
+  );
 }


### PR DESCRIPTION
## Problem
\`ekgf.org/dprod/spec/develop\` returned 404 after phase 5 went live. The middleware correctly identified develop as the current version (\`isCurrent: true\`) and entered the self-rewrite path, but the rewrite produced a broken request.

Two separate bugs, both in the self-rewrite branch:

1. **Rewrite chain fragility.** The old code rewrote to \`/dprod/spec\` and relied on the afterFiles rewrite \`/spec → /spec/index.html\` from \`next.config.ts\` to fire next. Chaining middleware rewrites through afterFiles rewrites isn't reliable in Next.js 16.
2. **NextURL basePath double-prefix.** Cloning \`req.nextUrl\` and setting \`pathname = "/dprod/spec/index.html"\` interacts with NextURL's internal basePath attribute and, under some conditions, emits \`/dprod/dprod/spec/index.html\` on the wire.

## Fix
- Middleware now rewrites **directly** to \`/dprod/spec/index.html\` — no dependency on chained rewrites.
- Destination URL is built with \`new URL(path, req.url)\` instead of \`req.nextUrl.clone()\`, using plain WHATWG URL semantics so the basePath isn't reapplied.
- Also adds \`x-dprod-mw-*\` response headers on every middleware decision, so the next spec-routing regression is diagnosable from a single \`curl -I\`.

## Verification
Preview at https://dprod-git-fix-spec-self-rewrite-ekgf.vercel.app

| Scenario | Result |
|---|---|
| \`/dprod/spec/fix-spec-self-rewrite\` (own branch — self-rewrite path) | HTTP 200, title \`EKGF DPROD Ontology\`, header \`x-dprod-mw: self-rewrite\` |
| \`/dprod/spec/develop\` (cross-branch → redirect) | HTTP 307, location \`dprod-git-develop-ekgf.vercel.app/dprod/spec\`, header \`x-dprod-mw: cross-branch\` |

Needs to merge promptly to unbreak \`ekgf.org/dprod/spec/develop\`.