### PR TITLE
feat(site): filter /spec-versions to open-PR branches only (#174)

### DIFF
--- a/site/src/lib/spec-versions.ts
+++ b/site/src/lib/spec-versions.ts
@@ -100,6 +100,55 @@ async function fetchDeployments(): Promise<VercelDeployment[]> {
   }
 }
 
+type GitHubPullRequest = {
+  head?: { ref?: string };
+  state?: string;
+};
+
+/**
+ * Returns the set of branches that have at least one open Pull Request on
+ * GitHub, plus the production branch "develop". Used to filter out Vercel
+ * deployments whose branch has already been merged: once a PR closes, its
+ * branch typically gets auto-deleted (or at least becomes irrelevant), and
+ * its Vercel preview deployment — while still reachable by URL — should no
+ * longer appear in the user-facing version picker.
+ *
+ * On failure (network error, missing token, rate limit, non-2xx response)
+ * the function returns `null` so callers can fail *open* — i.e. show every
+ * branch Vercel knows about rather than silently hide valid ones.
+ */
+async function fetchActiveBranches(): Promise<Set<string> | null> {
+  const token = process.env.GITHUB_TOKEN;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/EKGF/dprod/pulls?state=open&per_page=100",
+      {
+        headers,
+        next: { revalidate: 60 },
+      },
+    );
+    if (!res.ok) return null;
+    const prs = (await res.json()) as GitHubPullRequest[];
+    const branches = new Set<string>();
+    for (const pr of prs) {
+      const ref = pr.head?.ref;
+      if (ref) branches.add(ref);
+    }
+    // Always treat the production branch as active.
+    branches.add("develop");
+    return branches;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Returns the list of spec versions, in display order:
  *   1. The frozen 1.0 archive (always first, always present).
@@ -113,12 +162,21 @@ export async function getSpecVersions(): Promise<SpecVersion[]> {
   const currentBranch = process.env.VERCEL_GIT_COMMIT_REF;
   const versions: SpecVersion[] = [ARCHIVE_1_0];
 
-  const deployments = await fetchDeployments();
+  const [deployments, activeBranches] = await Promise.all([
+    fetchDeployments(),
+    fetchActiveBranches(),
+  ]);
 
   const seen = new Set<string>();
   for (const dep of deployments) {
     const branch = dep.meta?.githubCommitRef;
     if (!branch || EXCLUDED_BRANCHES.has(branch) || seen.has(branch)) continue;
+
+    // Fail open: when the GitHub lookup failed, keep every branch. When it
+    // succeeded, only keep branches with an open PR (or the production
+    // branch, which fetchActiveBranches() adds unconditionally).
+    if (activeBranches && !activeBranches.has(branch)) continue;
+
     seen.add(branch);
 
     const slug = branchToSlug(branch);


### PR DESCRIPTION
## Problem
\`/spec-versions\` was showing every branch Vercel had ever built as long as its latest deployment stayed in \`READY\` state — which in practice means it kept showing every merged PR branch for weeks. By the end of yesterday the picker had 7+ entries, most of which were dead merged branches.

## Fix
\`getSpecVersions()\` now cross-references Vercel deployments against GitHub's open Pull Requests and hides any branch whose PR has been merged or closed.

- New \`fetchActiveBranches()\` helper calls \`GET /repos/EKGF/dprod/pulls?state=open\` with the same 60 s ISR cache window as the Vercel deployment lookup. Returns the set of \`head.ref\` values plus \`"develop"\` unconditionally (production branch is always shown).
- Called in parallel with \`fetchDeployments()\` via \`Promise.all\`.
- **Fail open** — if GitHub is unreachable or the token is missing, \`fetchActiveBranches()\` returns \`null\` and the filter is skipped entirely. Better to show a stale extra branch than silently hide a real one.
- A \`GITHUB_TOKEN\` env var is already set on the Vercel project to stay under the 60 req/h anonymous rate limit.

## Verified
On the preview for this branch:

| Branch | Vercel READY | Open PR | Shown? |
|---|---|---|---|
| \`develop\` | ✓ | — (production) | ✅ always |
| \`feat/filter-merged-branches\` | ✓ | pending (this PR) | — |
| \`fix/spec-self-rewrite\` | ✓ | #182 merged | ❌ correctly hidden |
| \`fix/asset-prefix-basepath\` | ✓ | #181 merged | ❌ correctly hidden |
| \`feat/multi-zone\` | ✓ | #180 merged | ❌ correctly hidden |
| \`feat/header-omg-logo\` | ✓ | #179 merged | ❌ correctly hidden |

Picker on the preview currently shows only \`1.0 (OMG approved)\` and \`Develop (latest)\`. After this PR opens the GitHub API will include \`feat/filter-merged-branches\` in the open-PR list and within 60 s the picker on any deployment will pick it up.

## Preview
https://dprod-git-feat-filter-merged-branches-ekgf.vercel.app/dprod/spec-versions