### PR TITLE
chore(repo): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @tonyseale @nvar @rivettp @jgeluk @FroehlichMarcel @andrea-gioia @joshcornejo
+* @tonyseale @rivettp @jgeluk @FroehlichMarcel @joshcornejo @matthiasautrata
  


### PR DESCRIPTION
## Summary

- Add \`@matthiasautrata\` as a code owner (active contributor to data-contracts work via PR #160 and review feedback on PR #156)
- Remove \`@nvar\` and \`@andrea-gioia\`
- \`@joshcornejo\` was already an owner, no change there

## Effect

Affects future PRs targeting \`develop\`: \`@matthiasautrata\` will be auto-requested as a reviewer; \`@nvar\` and \`@andrea-gioia\` will no longer be. The \`main\` copy of CODEOWNERS is unchanged for now — it'll get synced at ballot time when the next merge from \`develop\` lands on \`main\`.

## Test plan
- [ ] Confirm the new owner set is what you want before merging
- [ ] After merge, open a throwaway PR against develop to verify the auto-requested reviewer set updates as expected (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)