### PR TITLE
feat(ontology)!: move vocabulary to DPROD/dprod; hyphenless version IRIs

### DIFF
--- a/dprod-contracts/README.md
+++ b/dprod-contracts/README.md
@@ -131,7 +131,7 @@ dprod-contracts/
 | Prefix | Namespace | Role |
 |--------|-----------|------|
 | `odrl:` | `http://www.w3.org/ns/odrl/2/` | Primary -- all standard constructs |
-| `dprod:` | `https://www.omg.org/spec/DPROD/` | Extensions (State, deadline, recurrence, DataOffer, DataContract, path, select, hierarchy) + domain-specific actions, operands, and concept values |
+| `dprod:` | `https://www.omg.org/spec/DPROD/dprod/` | Extensions (State, deadline, recurrence, DataOffer, DataContract, path, select, hierarchy) + domain-specific actions, operands, and concept values |
 
 ---
 

--- a/dprod-contracts/docs/contracts-guide.md
+++ b/dprod-contracts/docs/contracts-guide.md
@@ -82,7 +82,7 @@ Every contract starts with a type, profile declaration, and provider identity.
 
 ```turtle
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix ex:       <https://example.org/> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 

--- a/dprod-contracts/docs/formal-semantics.md
+++ b/dprod-contracts/docs/formal-semantics.md
@@ -985,7 +985,7 @@ Both sets are included in the evaluation result, with independent lifecycle trac
 ```turtle
 @prefix ex:   <http://example.org/> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 ex:agreement a odrl:Agreement ;

--- a/dprod-contracts/docs/overview.md
+++ b/dprod-contracts/docs/overview.md
@@ -19,7 +19,7 @@ DPROD Contracts is designed for organizations that need:
 
 ```turtle
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix ex:       <https://example.org/> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 
@@ -46,7 +46,7 @@ A `dprod:DataContract` activates an offer, binding both parties:
 
 ```turtle
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix ex:       <https://example.org/> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 
@@ -184,7 +184,7 @@ Domain Vocabulary
 | Prefix | Namespace | Role |
 |--------|-----------|------|
 | `odrl:` | `http://www.w3.org/ns/odrl/2/` | Primary -- all standard constructs |
-| `dprod:` | `https://www.omg.org/spec/DPROD/` | Core extensions (lifecycle, operand resolution, contract types) |
+| `dprod:` | `https://www.omg.org/spec/DPROD/dprod/` | Core extensions (lifecycle, operand resolution, contract types) |
 | `ex:` | (domain-specific) | Domain actions, operands, and concept values |
 
 ---

--- a/dprod-contracts/docs/policy-writers-guide.md
+++ b/dprod-contracts/docs/policy-writers-guide.md
@@ -30,7 +30,7 @@ A minimal data use policy:
 
 ```turtle
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix ex:       <https://example.org/> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 

--- a/dprod-contracts/docs/specification.md
+++ b/dprod-contracts/docs/specification.md
@@ -23,7 +23,7 @@ This document is a vocabulary reference for implementers. It defines every class
 
 ```turtle
 @prefix odrl:        <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dprod-shapes: <https://www.omg.org/spec/DPROD/contracts/shapes/> .
 @prefix rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .

--- a/dprod-contracts/dprod-contracts-prof.ttl
+++ b/dprod-contracts/dprod-contracts-prof.ttl
@@ -1,7 +1,7 @@
 # baseURI: https://www.omg.org/spec/DPROD/
 # prefix: dprod
 
-@prefix dprod: <https://www.omg.org/spec/DPROD/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .
 @prefix role: <http://www.w3.org/ns/dx/prof/role/> .
 @prefix dct: <http://purl.org/dc/terms/> .

--- a/dprod-contracts/dprod-contracts-shapes.ttl
+++ b/dprod-contracts/dprod-contracts-shapes.ttl
@@ -5,7 +5,7 @@
 
 @base <https://www.omg.org/spec/DPROD/contracts/shapes/> .
 @prefix dprod-shapes: <https://www.omg.org/spec/DPROD/contracts/shapes/> .
-@prefix dprod: <https://www.omg.org/spec/DPROD/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dprod-contracts/dprod-contracts.ttl
+++ b/dprod-contracts/dprod-contracts.ttl
@@ -6,7 +6,7 @@
 # imports: http://www.w3.org/ns/odrl/2/
 # prefix: dprod
 
-@prefix dprod: <https://www.omg.org/spec/DPROD/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .

--- a/dprod-contracts/examples/baseline.ttl
+++ b/dprod-contracts/examples/baseline.ttl
@@ -18,7 +18,7 @@
 # =============================================================================
 
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dct:      <http://purl.org/dc/terms/> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .

--- a/dprod-contracts/examples/data-contract.ttl
+++ b/dprod-contracts/examples/data-contract.ttl
@@ -6,7 +6,7 @@
 # =============================================================================
 
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dct:      <http://purl.org/dc/terms/> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .

--- a/dprod-contracts/examples/data-use-policy.ttl
+++ b/dprod-contracts/examples/data-use-policy.ttl
@@ -8,7 +8,7 @@
 # =============================================================================
 
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dct:      <http://purl.org/dc/terms/> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .

--- a/dprod-contracts/examples/odcs.ttl
+++ b/dprod-contracts/examples/odcs.ttl
@@ -16,7 +16,7 @@
 # =============================================================================
 
 @prefix odrl:     <http://www.w3.org/ns/odrl/2/> .
-@prefix dprod:    <https://www.omg.org/spec/DPROD/> .
+@prefix dprod:    <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dct:      <http://purl.org/dc/terms/> .
 @prefix skos:     <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .

--- a/examples/data-lineage/README.md
+++ b/examples/data-lineage/README.md
@@ -119,7 +119,7 @@ In Linked Data, this would use a query such as:
 ```sparql
 PREFIX :      <https://y.com/data-product/>
 PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX dprod: <https://www.omg.org/spec/DPROD/>
+PREFIX dprod: <https://www.omg.org/spec/DPROD/dprod/>
 
 SELECT DISTINCT ?input
 WHERE

--- a/ontology/dprod/dprod-ontology.ttl
+++ b/ontology/dprod/dprod-ontology.ttl
@@ -2,8 +2,8 @@
 # imports: http://www.w3.org/ns/dcat#
 # prefix: dprod
 
-@base <https://www.omg.org/spec/DPROD/> .
-@prefix dprod: <https://www.omg.org/spec/DPROD/> .
+@base <https://www.omg.org/spec/DPROD/dprod/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -38,7 +38,7 @@ dprod:
   dct:contributor <https://www.linkedin.com/in/tonyseale> ;
   dct:contributor <https://www.linkedin.com/in/joshuacornejo> ;
   owl:imports dcat: ;
-  owl:versionIRI <https://www.omg.org/spec/DPROD/2026-06-01/> ;
+  owl:versionIRI <https://www.omg.org/spec/DPROD/20260601/dprod/> ;
 .
 
 ############################# DPROD Classes  #########################

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -7,7 +7,7 @@
 
 @base <https://www.omg.org/spec/DPROD/shapes/> .
 @prefix dprod-shapes: <https://www.omg.org/spec/DPROD/shapes/> .
-@prefix dprod: <https://www.omg.org/spec/DPROD/> .
+@prefix dprod: <https://www.omg.org/spec/DPROD/dprod/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix odrl:	<http://www.w3.org/ns/odrl/2/>.
@@ -36,7 +36,7 @@ dprod-shapes:
   owl:imports dcat: ;
   owl:imports sh: ;
   owl:imports dprod: ;
-  owl:versionIRI <https://www.omg.org/spec/DPROD/2026-06-01/shapes/> ;
+  owl:versionIRI <https://www.omg.org/spec/DPROD/20260601/shapes/> ;
   sh:declare [
     sh:prefix "dprod" ;
     sh:namespace "https://www.omg.org/spec/DPROD/" ;

--- a/respec/template.html
+++ b/respec/template.html
@@ -466,7 +466,7 @@
     and enables federated search across multiple sites using a uniform query mechanism and structure.
   </p>
   <p>
-    The namespace for DPROD terms is <a href="https://www.omg.org/spec/DPROD/">https://www.omg.org/spec/DPROD/</a>
+    The namespace for DPROD terms is <a href="https://www.omg.org/spec/DPROD/dprod/">https://www.omg.org/spec/DPROD/dprod/</a>
   </p>
   <p>
     The suggested prefix for the DPROD namespace is <strong><code>dprod</code></strong>
@@ -607,7 +607,7 @@
         <code>dprod</code>
       </td>
       <td>
-        <code>https://www.omg.org/spec/DPROD/</code>
+        <code>https://www.omg.org/spec/DPROD/dprod/</code>
       </td>
       <td>[[dprod]]</td>
     </tr>

--- a/spec-generator/globals.py
+++ b/spec-generator/globals.py
@@ -3,7 +3,7 @@ from rdflib import Namespace, RDF, RDFS, SH, SKOS, OWL, XSD, DCAT, DCTERMS
 debug = False
 show_source = False
 
-ontology_namespace_iri = "https://www.omg.org/spec/DPROD/"
+ontology_namespace_iri = "https://www.omg.org/spec/DPROD/dprod/"
 DPROD = Namespace(ontology_namespace_iri)
 shapes_graph_ns_iri = "https://www.omg.org/spec/DPROD/shapes/"
 DPROD_SHAPES = Namespace(shapes_graph_ns_iri)


### PR DESCRIPTION
Closes #204.

## Summary

Moves the core DPROD vocabulary from `https://www.omg.org/spec/DPROD/` to
`https://www.omg.org/spec/DPROD/dprod/` (mirroring the `…/shapes/` sibling) and
drops the hyphens from the date stamp in the versioned IRIs.

- **Vocabulary**: `dprod:DataProduct` → `https://www.omg.org/spec/DPROD/dprod/DataProduct` (every `dprod:` term moves).
- **Version IRIs**:
  - ontology `owl:versionIRI` → `https://www.omg.org/spec/DPROD/20260601/dprod/`
  - shapes `owl:versionIRI` → `https://www.omg.org/spec/DPROD/20260601/shapes/`
- `dct:modified` keeps proper `xsd:date` hyphens (`"2026-06-01"`).

Applied via the `@prefix dprod:` declarations + the spec-generator namespace
constant (which regenerates `dprod-context.jsonld`), plus the `dprod-contracts`
staging files, examples, and docs. 18 files, +24/−24.

## ⚠️ Breaking change

All published DPROD term IRIs move under `/dprod/`.

## Out of scope (left unchanged — see #204)

- ODRL **profile IRI** (`odrl:profile` / `prof:Profile` at `…/DPROD/`) — separate resource.
- ReSpec spec-document URLs (`latestVersion` / `href`).
- `…/DPROD/data/` code-list namespace.

## Test plan

- [x] All ontology / shapes / contracts / example TTLs parse (rdflib).
- [x] Contracts SHACL suite `dprod-contracts/validate.py` passes.
- [x] Spec generator builds clean (exit 0); regenerated `dprod-context.jsonld` maps `dprod` → `…/DPROD/dprod/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
