### PR TITLE
fix(spec): point header IRIs at DPROD/dprod ontology IRI

### DIFF
--- a/respec/template.html
+++ b/respec/template.html
@@ -11,7 +11,7 @@
     const respecConfig = {
       // Working Groups ids at https://respec.org/w3c/groups/
       // group: "Semantic Data Products Working Group",
-      latestVersion: "https://www.omg.org/spec/DPROD/",
+      latestVersion: "https://www.omg.org/spec/DPROD/dprod/",
       edDraftURI: "https://ekgf.org/spec/{{ branch }}/",
       specStatus: "base",
       editors: [
@@ -144,7 +144,7 @@
         },
         dprod: {
           title: "Data Product Ontology",
-          href: "https://www.omg.org/spec/DPROD/",
+          href: "https://www.omg.org/spec/DPROD/dprod/",
           authors: [
             "Tony Seale",
             "Natasa Varytimou",


### PR DESCRIPTION
Closes #206.

## Summary

After the vocabulary move to `https://www.omg.org/spec/DPROD/dprod/` (#205), the
published ReSpec header still showed the bare `https://www.omg.org/spec/DPROD/`.
Point it at the relocated ontology IRI:

- `latestVersion` → `https://www.omg.org/spec/DPROD/dprod/`
- `localBiblio.dprod.href` (`[[dprod]]` citation) → `https://www.omg.org/spec/DPROD/dprod/`

(Unversioned ontology IRI for "latest"; the dated `owl:versionIRI` is `…/20260601/dprod/`.)

## Test plan
- [x] Spec generator builds clean; rendered `index.html` header now reads `…/DPROD/dprod/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
