### PR TITLE
fix(ontology): bind dprod sh:namespace to DPROD/dprod + update comments

### DIFF
--- a/dprod-contracts/dprod-contracts-shapes.ttl
+++ b/dprod-contracts/dprod-contracts-shapes.ttl
@@ -29,7 +29,7 @@ dprod-shapes:
   owl:versionInfo "0.7" ;
   sh:declare [
     sh:prefix "dprod" ;
-    sh:namespace "https://www.omg.org/spec/DPROD/" ;
+    sh:namespace "https://www.omg.org/spec/DPROD/dprod/" ;
   ] ;
   sh:declare [
     sh:prefix "dprod-shapes" ;

--- a/dprod-contracts/dprod-contracts.ttl
+++ b/dprod-contracts/dprod-contracts.ttl
@@ -1,8 +1,8 @@
 # All DPROD-contracts terms are minted in the core dprod: namespace
-# (https://www.omg.org/spec/DPROD/); this file contributes additional
+# (https://www.omg.org/spec/DPROD/dprod/); this file contributes additional
 # axioms to the DPROD ontology rather than minting under a separate
 # contracts namespace.
-# imports: https://www.omg.org/spec/DPROD/
+# imports: https://www.omg.org/spec/DPROD/dprod/
 # imports: http://www.w3.org/ns/odrl/2/
 # prefix: dprod
 

--- a/ontology/dprod/dprod-ontology.ttl
+++ b/ontology/dprod/dprod-ontology.ttl
@@ -1,4 +1,4 @@
-# baseURI: https://www.omg.org/spec/DPROD/
+# baseURI: https://www.omg.org/spec/DPROD/dprod/
 # imports: http://www.w3.org/ns/dcat#
 # prefix: dprod
 

--- a/ontology/dprod/dprod-shapes.ttl
+++ b/ontology/dprod/dprod-shapes.ttl
@@ -1,7 +1,7 @@
 # baseURI: https://www.omg.org/spec/DPROD/shapes/
 # imports: http://www.w3.org/ns/dcat#
 # imports: http://www.w3.org/ns/shacl#
-# imports: https://www.omg.org/spec/DPROD/
+# imports: https://www.omg.org/spec/DPROD/dprod/
 # prefix: dprod-shapes
 
 
@@ -39,7 +39,7 @@ dprod-shapes:
   owl:versionIRI <https://www.omg.org/spec/DPROD/20260601/shapes/> ;
   sh:declare [
     sh:prefix "dprod" ;
-    sh:namespace "https://www.omg.org/spec/DPROD/" ;
+    sh:namespace "https://www.omg.org/spec/DPROD/dprod/" ;
    ] ;
   sh:declare [
     sh:prefix "dprod-shapes" ;


### PR DESCRIPTION
Closes #207. Follow-up to #205 / #204.

## Summary

Fixes references the namespace move missed because they aren't `dprod:`-prefixed names:

- **`sh:declare` for prefix `dprod`** in `dprod-shapes.ttl` and `dprod-contracts-shapes.ttl` → `https://www.omg.org/spec/DPROD/dprod/`. This was a correctness bug: SPARQL-based SHACL constraints using `dprod:` resolved to the old namespace.
- **`# baseURI:` / `# imports:`** header comments referencing the core ontology IRI.

## Deliberately NOT included

The ODRL **profile IRI** (the `prof:Profile` subject, the `sh:hasValue` enforcement + messages, and all `odrl:profile` references) stays at the bare `https://www.omg.org/spec/DPROD/` for now — its target is a modeling decision tracked in **#210**. `odrl:profile` and `sh:hasValue` remain mutually consistent, so validation is unaffected.

## Test plan
- [x] All affected TTLs parse.
- [x] Contracts SHACL suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)