### PR TITLE
Reject odrl:Request until its contract semantics are defined

### DIFF
--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           echo "Installing dependencies..."
           pip install -r requirements.txt
+          echo "Running contracts tests..."
+          python -m unittest discover -s dprod-contracts/tests
           echo "Running spec generator..."
           python spec-generator/main.py
       - name: Upload artifact

--- a/dprod-contracts/docs/formal-semantics.md
+++ b/dprod-contracts/docs/formal-semantics.md
@@ -220,6 +220,8 @@ Request ::= Request(agent: Agent, action: Action, asset: Asset, context: Context
 Context ::= Map<String, Value>
 ```
 
+The formal `Request` evaluation input is not an RDF `odrl:Request` policy. It is an abstract runtime authorization query evaluated against supported policy types. Until DPROD defines a transition model connecting `odrl:Offer`, `odrl:Request`, and `odrl:Agreement`, an RDF `odrl:Request` is outside the supported policy grammar and MUST be rejected by SHACL validation.
+
 **Note**: Context properties correspond to the leaf of `dprod:path` declarations (e.g., `dprod:path odrl:purpose` resolves `?request odrl:purpose ?value`).
 
 ---

--- a/dprod-contracts/docs/specification.md
+++ b/dprod-contracts/docs/specification.md
@@ -375,7 +375,7 @@ Shapes are defined in `dprod-contracts-shapes.ttl`. Key constraints:
 | `dprod-shapes:RejectRemedyShape` | `odrl:remedy` | Noted as future extension |
 | `dprod-shapes:RejectConsequenceShape` | `odrl:consequence` | Noted as future extension |
 | `dprod-shapes:RejectTicketShape` | `odrl:Ticket` | Not supported |
-| `dprod-shapes:RejectRequestShape` | `odrl:Request` | Not supported |
+| `dprod-shapes:RejectRequestShape` | `odrl:Request` | DPROD contracts reject odrl:Request because Offer-Request-Agreement semantics are undefined; support is deferred. |
 | `dprod-shapes:RejectAssetCollectionShape` | `odrl:AssetCollection` | Use `dprod:partOf` instead |
 | `dprod-shapes:RejectPartyCollectionShape` | `odrl:PartyCollection` | Use `dprod:memberOf` instead |
 | `dprod-shapes:RejectInheritAllowedShape` | `odrl:inheritAllowed` | Not supported |
@@ -417,10 +417,12 @@ DPROD Contracts restricts certain ODRL features:
 | `odrl:remedy` | Rejected | Noted as future extension |
 | `odrl:consequence` | Rejected | Noted as future extension |
 | `odrl:Ticket` | Not used | Not applicable to data governance |
-| `odrl:Request` | Not used | Not applicable |
+| `odrl:Request` | Rejected (support deferred) | Offer-Request-Agreement semantics are undefined; accepting it would imply unsupported semantics. |
 | `odrl:assignee` (on Duty) | Replaced by `dprod:subjectOfDuty` | `dprod:subjectOfDuty rdfs:subPropertyOf odrl:function` -- avoids role overloading on duties |
 | `odrl:AssetCollection` | Not used | Use `dprod:partOf` hierarchy instead (`rdfs:subPropertyOf odrl:partOf` bridges to ODRL) |
 | `odrl:PartyCollection` | Not used | Use `dprod:memberOf` hierarchy instead (`rdfs:subPropertyOf odrl:partOf` bridges to ODRL) |
+
+DPROD contracts reject odrl:Request because Offer-Request-Agreement semantics are undefined; support is deferred. An `odrl:Request` MUST fail SHACL validation until the profile defines how it relates to `odrl:Offer` and `odrl:Agreement` and what evaluator behavior follows.
 
 ---
 

--- a/dprod-contracts/dprod-contracts-shapes.ttl
+++ b/dprod-contracts/dprod-contracts-shapes.ttl
@@ -461,7 +461,7 @@ dprod-shapes:RejectRequestShape
   a sh:NodeShape ;
   sh:targetClass odrl:Request ;
   sh:sparql [
-    sh:message "DPROD contracts do not support odrl:Request." ;
+    sh:message "DPROD contracts reject odrl:Request because Offer-Request-Agreement semantics are undefined; support is deferred." ;
     sh:severity sh:Violation ;
     sh:select """
       SELECT $this WHERE { $this a odrl:Request }

--- a/dprod-contracts/tests/test_request_rejection.py
+++ b/dprod-contracts/tests/test_request_rejection.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import unittest
+
+from pyshacl import validate
+from rdflib import Graph
+
+
+CONTRACTS_DIR = Path(__file__).resolve().parents[1]
+SHAPES_FILE = CONTRACTS_DIR / "dprod-contracts-shapes.ttl"
+ONTOLOGY_FILE = CONTRACTS_DIR / "dprod-contracts.ttl"
+SPECIFICATION_FILE = CONTRACTS_DIR / "docs" / "specification.md"
+FORMAL_SEMANTICS_FILE = CONTRACTS_DIR / "docs" / "formal-semantics.md"
+
+REQUEST_REJECTION_MESSAGE = (
+    "DPROD contracts reject odrl:Request because Offer-Request-Agreement "
+    "semantics are undefined; support is deferred."
+)
+
+REQUEST_DATA = """
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+
+<urn:dprod:test:request> a odrl:Request .
+"""
+
+
+class RequestRejectionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.shapes = Graph().parse(SHAPES_FILE, format="turtle")
+        cls.ontology = Graph().parse(ONTOLOGY_FILE, format="turtle")
+
+    def test_request_is_rejected_with_the_deferred_semantics_reason(self) -> None:
+        data = Graph().parse(data=REQUEST_DATA, format="turtle")
+
+        conforms, _, report = validate(
+            data_graph=data,
+            shacl_graph=self.shapes,
+            ont_graph=self.ontology,
+            inference="rdfs",
+            advanced=True,
+        )
+
+        self.assertFalse(conforms)
+        self.assertIn(REQUEST_REJECTION_MESSAGE, report)
+
+    def test_specification_records_the_deferred_rejection(self) -> None:
+        specification = SPECIFICATION_FILE.read_text(encoding="utf-8")
+
+        self.assertIn(REQUEST_REJECTION_MESSAGE, specification)
+
+    def test_formal_request_is_distinct_from_odrl_request(self) -> None:
+        formal_semantics = FORMAL_SEMANTICS_FILE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "The formal `Request` evaluation input is not an RDF "
+            "`odrl:Request` policy.",
+            formal_semantics,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- retain fail-fast SHACL rejection of `odrl:Request` and give it the agreed semantic rationale
- distinguish the formal evaluator's abstract `Request` input from an RDF `odrl:Request` policy
- document that support is deferred until Offer–Request–Agreement semantics and evaluator behavior are defined
- add regression coverage and run the contract tests in CI

## Root cause

DPROD has no operational model for an isolated `odrl:Request`: it does not define how a Request relates to an `odrl:Offer` or `odrl:Agreement`, which transitions apply, or what an evaluator must do with it. Accepting the class would therefore falsely claim semantic support.

The profile continues to reject `odrl:Request` explicitly and fail-fast until that model exists. `odrl:Ticket` is unchanged because no decision has been made for it.

## Validation

- `.venv/bin/python -m unittest discover -s dprod-contracts/tests`
- `python3 -m unittest discover -s tests`
- `.venv/bin/python dprod-contracts/validate.py`
- `bash build.sh`
- `git diff --check`

Addresses the `odrl:Request` decision in #215 without closing the still-open `odrl:Ticket` question.